### PR TITLE
Bring back inst_hostname (now named firstboot_hostname). bnc#911952

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -133,7 +133,7 @@
                 <module>
                     <label>Host Name</label>
                     <enabled config:type="boolean">false</enabled>
-                    <name>inst_hostname</name>
+                    <name>firstboot_hostname</name>
                 </module>
                 <module>
                     <label>Network</label>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb  5 09:08:40 UTC 2015 - ancor@suse.com
+
+- Fixed the step for host name configuration (bnc#911952)
+- 3.1.6
+
+-------------------------------------------------------------------
 Tue Nov 18 12:56:02 UTC 2014 - ancor@suse.com
 
 - Added missing module for DHCP (bnc#895359, bnc#904527).

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.5
+Version:        3.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,8 @@ client_DATA = \
   clients/firstboot_license_novell.rb \
   clients/firstboot_network_write.rb \
   clients/firstboot_setup_dhcp.rb \
-  clients/firstboot_auto.rb
+  clients/firstboot_auto.rb \
+  clients/firstboot_hostname.rb
 
 yncludedir = @yncludedir@/firstboot
 ynclude_DATA = \

--- a/src/clients/firstboot_hostname.rb
+++ b/src/clients/firstboot_hostname.rb
@@ -1,0 +1,83 @@
+# encoding: utf-8
+
+#***************************************************************************
+#
+# Copyright (c) 2015 SUSE LLC
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+#**************************************************************************
+#
+module Yast
+  # Client to set the hostname during first boot
+  #
+  # This is just a renamed version of InstHostnameClient, which was removed from
+  # YaST2-Network when the second stage was removed from the installation
+  # process
+  class FirstbootHostnameClient < Client
+    def main
+      Yast.import "UI"
+
+      textdomain "network"
+
+      Yast.import "Arch"
+      Yast.import "DNS"
+      Yast.import "Host"
+      Yast.import "NetworkConfig"
+      Yast.import "String"
+      Yast.import "Wizard"
+      Yast.import "ProductControl"
+      Yast.import "ProductFeatures"
+
+      Yast.include self, "network/services/dns.rb"
+
+      # only once, do not re-propose if user gets back to this dialog from
+      # the previous screen - bnc#438124
+      if !DNS.proposal_valid
+        DNS.Read # handles NetworkConfig too
+        DNS.ProposeHostname # generate random hostname, if none known so far
+
+        # propose settings
+        DNS.dhcp_hostname = !Arch.is_laptop
+
+        # get default value, from control.xml
+        DNS.write_hostname = DNS.DefaultWriteHostname
+      end
+
+      Wizard.SetDesktopIcon("dns")
+      ret = HostnameDialog()
+
+      if ret == :next
+        Host.Read
+        Host.ResolveHostnameToStaticIPs
+        Host.Write
+
+        # do not let Lan override us, #152218
+        DNS.proposal_valid = true 
+
+        # In InstHostname writing was delayed to do it with the rest of
+        # network configuration in lan_proposal.
+        # In FirstbootHostname it's probably safer to do it right away.
+        DNS.Write
+      end
+
+      ret
+    end
+  end
+end
+
+Yast::FirstbootHostnameClient.new.main


### PR DESCRIPTION
The module used to be at yast-network but was removed alongside stage 2.