### PR TITLE
Forcing mode "installation" for firstboot to always use the correct workflow

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 16 10:29:47 CEST 2015 - locilka@suse.com
+
+- Forcing mode "installation" for firstboot to always use the
+  correct workflow (bsc#924278)
+- 3.1.5.2
+
+-------------------------------------------------------------------
 Thu Feb  5 09:08:40 UTC 2015 - ancor@suse.com
 
 - Fixed the step for host name configuration

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.5.1
+Version:        3.1.5.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firstboot.rb
+++ b/src/clients/firstboot.rb
@@ -42,6 +42,7 @@ module Yast
 
       Wizard.OpenNextBackStepsDialog
 
+      # Always force the mode (bsc#924278)
       Mode.SetMode("installation")
       ProductControl.AddWizardSteps([{ "stage" => "firstboot", "mode" => "installation" }])
 

--- a/src/clients/firstboot.rb
+++ b/src/clients/firstboot.rb
@@ -42,10 +42,8 @@ module Yast
 
       Wizard.OpenNextBackStepsDialog
 
-      @wizard_mode = Mode.test ? "installation" : Mode.mode
-
-      @stage_mode = [{ "stage" => "firstboot", "mode" => @wizard_mode }]
-      ProductControl.AddWizardSteps(@stage_mode)
+      Mode.SetMode("installation")
+      ProductControl.AddWizardSteps([{ "stage" => "firstboot", "mode" => "installation" }])
 
       # Do log Report messages by default (#180862)
       Report.LogMessages(true)


### PR DESCRIPTION
- When systems has been upgraded from previous version anytime before, /etc/install.inf contains Upgrade: 1, which automatically changes the mode into "update", even in firstboot, but then ProductWorkflow does not find the appropriate steps in control file
- bsc#924278