### PR TITLE
updated registration client in firstboot.xml (bsc#970572)

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -183,7 +183,7 @@
                 </module>
                 <module>
                     <label>Customer Center</label>
-                    <name>inst_suse_register</name>
+                    <name>registration</name>
                     <enabled config:type="boolean">false</enabled>
                 </module>
                 <module>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 21 12:23:54 UTC 2016 - lslezak@suse.cz
+
+- Fixed firstboot.xml to call the correct client for registration
+  (bsc#970572)
+- 3.1.12
+
+-------------------------------------------------------------------
 Mon Jan  4 12:50:27 UTC 2016 - ancor@suse.com
 
 - Fixed firstboot.xml to call the correct client for LAN

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The `inst_suse_register` client has been removed, use the new `registration` instead.

See [bug#970572](https://bugzilla.suse.com/show_bug.cgi?id=970572).

- 3.1.12