### PR TITLE
Restore HostnameDialog removed from yast2-network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ doc/*.html
 doc/css
 doc/html/
 doc/js
-firstboot.pot
 install-sh
 missing
 pluglib-bindings.ami
+*.pot

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 30 17:47:59 UTC 2017 - knut.anderssen@suse.com
+
+- Bring back HostnameDialog adding it into firstboot_hostname once
+  it was removed from yast2-network (bsc#1028371, bsc#1070388).
+- 3.1.18
+
+-------------------------------------------------------------------
 Wed Aug 24 11:22:55 UTC 2016 - jreidinger@suse.com
 
 - fix not showing errors as popup in firstboot (bnc#994892)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.17
+Version:        3.1.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/4UcFx444/1272-3-l3-sles12-sp3-1070388-firstboot-set-hostname-dialog-fails)

Just added the method as it was defined in yast2-network.