### PR TITLE
Added firstboot.glade symlink (bsc#1085888)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ doc/autodocs
 coverage
 
 # Generated
-control/firstboot.glade
 missing
 /.yardoc
 /*.pot

--- a/configure.in.in
+++ b/configure.in.in
@@ -9,11 +9,6 @@
 
 AX_CHECK_DOCBOOK
 
-## Nasty hack: xgettext doesn't work for XML files, so let's symlink it
-( cd control; ln -sf firstboot.xml firstboot.glade )
-
-find control -name \*.glade | LC_ALL=C sort > POTFILES
-
 # this module does not have any YCP modules
 # (defined explicitly here as using (@)YAST2-CHECKS-YCP(@) would add yast2-core
 # build dependency back)

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -7,11 +7,7 @@ control_DATA = \
 
 # Note: The control.glade -> control.xml symlink is required to make xgettext
 # auto-detect the type of this file (glade) so it will extract all
-# <label>..</label> tags. The symlink is created in the toplevel
-# configure.in.in file upon "autoconf" (via "make -f Makefile.cvs").
-# Unfortunately, CVS doesn't support checking in symlinks - it would duplicate
-# the file. 
-
+# <label>..</label> tags.
 
 EXTRA_DIST =  $(control_DATA)
 

--- a/control/firstboot.glade
+++ b/control/firstboot.glade
@@ -1,0 +1,1 @@
+firstboot.xml

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 20 16:35:46 UTC 2018 - lslezak@suse.cz
+
+- Added firstboot.glade symlink to include also the firstboot.xml
+  texts in the generated POT file, removed the old Makefile hack
+  (bsc#1085888)
+- 4.0.4
+
+-------------------------------------------------------------------
 Thu Feb  8 08:38:38 UTC 2018 - jsrain@suse.cz
 
 - adapted to changes in the Language module (bsc#1079852)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -63,6 +63,11 @@ created to personalize the system.
 %install
 %yast_install
 
+# Remove the license from the /usr/share/doc/packages directory,
+# it is also included in the /usr/share/licenses directory by using
+# the %license tag.
+rm $RPM_BUILD_ROOT/%{yast_docdir}/COPYING
+
 mkdir -p $RPM_BUILD_ROOT/usr/share/firstboot/scripts
 
 
@@ -91,7 +96,7 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/firstboot/scripts
 %{_fillupdir}/sysconfig.firstboot
 /usr/share/firstboot
 %doc %{yast_docdir}
-%doc COPYING
+%license COPYING
 %dir /etc/YaST2/
 /etc/YaST2/*.xml
 %dir /usr/share/autoinstall


### PR DESCRIPTION
- Include also the `firstboot.xml` texts in the generated POT file, for XML files we need a `*.glade` symlink
- Removed the old Makefile hack (CVS does not support symlinks, Git does), Jenkins does NOT run (auto)make before running `y2makepot`
- Additionally use the `%license` flag for the license file in the spec file
- 4.0.4