### PR TITLE
Unified halt being called during the cleanup

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 11 11:10:40 UTC 2018 - knut.anderssen@suse.com
+
+- Allow going back from finish step and unified halt (bsc#1095253)
+- 4.0.5
+
+-------------------------------------------------------------------
 Tue Mar 20 16:35:46 UTC 2018 - lslezak@suse.cz
 
 - Added firstboot.glade symlink to include also the firstboot.xml

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -31,8 +31,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 Requires:	yast2 >= 2.16.23
 # Language::SwitchToEnglishIfNeeded
 Requires:	yast2-country >= 2.19.5
-# new version of inst_license
-Requires:	yast2-installation >= 2.19.0
+# Rely on the YaST2-Firstboot.service for halting the system on failure
+Requires:	yast2-installation >= 4.0.65
 # network autoconfiguration
 Requires:	yast2-network >= 3.1.91
 

--- a/scripts/Firstboot-Stage/S09-cleanup
+++ b/scripts/Firstboot-Stage/S09-cleanup
@@ -49,3 +49,9 @@ if [ -e "/var/lib/YaST2/firstboot_reboot_after_finish" ] ; then
     rm /var/lib/YaST2/firstboot_reboot_after_finish
     /sbin/reboot
 fi
+
+if [ -e "/var/lib/YaST2/firstboot_halt_after_finish" ] ; then
+    log "\tHalting system as requested by firstboot..."
+    rm /var/lib/YaST2/firstboot_halt_after_finish
+    exit 1
+fi

--- a/scripts/Firstboot-Stage/S09-cleanup
+++ b/scripts/Firstboot-Stage/S09-cleanup
@@ -53,5 +53,8 @@ fi
 if [ -e "/var/lib/YaST2/firstboot_halt_after_finish" ] ; then
     log "\tHalting system as requested by firstboot..."
     rm /var/lib/YaST2/firstboot_halt_after_finish
+    # Instead of calling halt directly we will rely on systemd
+    # failed state, that is OnFailure=shutdown.target in the
+    # YaST2-Firstboot.service (bsc#1095251)
     exit 1
 fi

--- a/src/clients/firstboot.rb
+++ b/src/clients/firstboot.rb
@@ -99,10 +99,20 @@ module Yast
 
         if @action == "halt"
           Builtins.y2milestone("Halting the system...")
-          SCR.Execute(path(".target.bash"), "/sbin/halt")
+          SCR.Execute(path(".target.bash"),
+               Builtins.sformat(
+              "touch %1/firstboot_halt_after_finish",
+              Directory.vardir
+            )
+          )
         elsif @action == "reboot"
           Builtins.y2milestone("Rebooting the system...")
-          SCR.Execute(path(".target.bash"), "/sbin/reboot")
+          SCR.Execute(path(".target.bash"),
+               Builtins.sformat(
+              "touch %1/firstboot_reboot_after_finish",
+              Directory.vardir
+            )
+          )
         elsif @action == "continue"
           Builtins.y2milestone("Finishing Yast...")
         else

--- a/src/clients/firstboot.rb
+++ b/src/clients/firstboot.rb
@@ -97,6 +97,8 @@ module Yast
           @action
         )
 
+        # The S09-cleanup script is responsible of rebooting or halting the
+        # system depending on the existence of the specifig flag files
         if @action == "halt"
           Builtins.y2milestone("Halting the system...")
           SCR.Execute(path(".target.bash"),

--- a/src/clients/firstboot_finish.rb
+++ b/src/clients/firstboot_finish.rb
@@ -142,6 +142,7 @@ module Yast
         GetInstArgs.enable_next
       )
 
+      Wizard.HideAbortButton
       Wizard.SetNextButton(:next, Label.FinishButton)
       Wizard.SetFocusToNextButton
 

--- a/src/clients/firstboot_license.rb
+++ b/src/clients/firstboot_license.rb
@@ -59,11 +59,7 @@ module Yast
 
       @result = WFM.CallFunction("inst_license", [@args])
 
-      if @result == :halt
-        UI.CloseDialog
-        Builtins.y2milestone("Halting the system...")
-        SCR.Execute(path(".target.bash"), "/sbin/halt")
-      end
+      UI.CloseDialog if @result == :halt
 
       deep_copy(@result)
     end

--- a/src/clients/firstboot_license_novell.rb
+++ b/src/clients/firstboot_license_novell.rb
@@ -69,11 +69,7 @@ module Yast
 
       @result = WFM.CallFunction("inst_license", [@args])
 
-      if @result == :halt
-        UI.CloseDialog
-        Builtins.y2milestone("Halting the system...")
-        SCR.Execute(path(".target.bash"), "/sbin/halt")
-      end
+      UI.CloseDialog if @result == :halt
 
       deep_copy(@result)
     end

--- a/src/clients/firstboot_licenses.rb
+++ b/src/clients/firstboot_licenses.rb
@@ -71,11 +71,7 @@ module Yast
 
       @result = WFM.CallFunction("inst_license", [@args])
 
-      if @result == :halt
-        UI.CloseDialog
-        Builtins.y2milestone("Halting the system...")
-        SCR.Execute(path(".target.bash"), "/sbin/halt")
-      end
+      UI.CloseDialog if @result == :halt
 
       deep_copy(@result)
     end

--- a/src/clients/firstboot_write.rb
+++ b/src/clients/firstboot_write.rb
@@ -39,6 +39,7 @@ module Yast
       Yast.import "ProductFeatures"
       Yast.import "Wizard"
 
+      return :back if GetInstArgs.going_back
 
       @progress_stages = [
         # progress stages
@@ -93,10 +94,6 @@ module Yast
         path(".sysconfig.windowmanager.DEFAULT_WM"),
         Firstboot.default_wm
       )
-
-
-      # Dont run firstboot next time
-      SCR.Execute(path(".target.remove"), Firstboot.reconfig_file)
 
       # save product features if they do not exist
       if !FileUtils.Exists("/etc/YaST2/ProductFeatures")


### PR DESCRIPTION
- Unified the way we were halting the system. (https://bugzilla.suse.com/show_bug.cgi?id=1095251)
- Allowed to going back from the congratulate step. (https://bugzilla.suse.com/show_bug.cgi?id=1095253)
- It also depends on yast/yast-installation#716

## Finish step
![Congratulate](https://user-images.githubusercontent.com/7056681/41228225-823e107c-6d6f-11e8-9eb8-e4ab5df79f0e.png)
## Go back allowed
![GoingBack](https://user-images.githubusercontent.com/7056681/41228223-800ab95e-6d6f-11e8-9623-ea580d4a01ed.png)
## OnFailure
![abortingshutdown](https://user-images.githubusercontent.com/7056681/41232600-c99a3e5a-6d7e-11e8-9db4-a612fa17443b.png)
## OnFailure doesn't remove the reconfig_system file as expected
![rebootafterabort](https://user-images.githubusercontent.com/7056681/41233231-b4fe72b6-6d80-11e8-914a-df66c25949a9.png)
