### PR TITLE
Configuration management module integration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+# use the shared YaST defaults
+inherit_from:
+  /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml
+
+# Don't enforce any particular name for block params
+SingleLineBlockParams:
+  Enabled: false
+
+# Enforce if/unless at the end only for really short lines
+Style/IfUnlessModifier:
+  MaxLineLength: 60
+
+AllCops:
+  Exclude:
+    - 'src/modules/**/*'
+    - 'src/include/**/*'
+    - 'testsuite/**/*'
+    - 'src/clients/*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM yastdevel/ruby
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  docbook-xsl-stylesheets
+  docbook-xsl-stylesheets yast2-configuration-management
 COPY . /usr/src/app
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  #lets ignore license check for now
+  # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 14 13:00:48 UTC 2018 - igonzalezsosa@suse.com
+
+- Add integration with the yast2-configuration-management module
+  (fate#322722).
+- 4.1.3
+
+-------------------------------------------------------------------
 Thu Dec  6 18:27:25 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -39,7 +39,7 @@ Requires:	yast2-network >= 3.1.91
 BuildArchitectures:	noarch
 
 Requires:       yast2-ruby-bindings >= 1.0.0
-Requires:       yast2-configuration-management >= 4.0.4
+Requires:       yast2-configuration-management >= 4.1.1
 
 Summary:	YaST2 - Initial System Configuration
 PreReq:         %fillup_prereq

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,6 +39,7 @@ Requires:	yast2-network >= 3.1.91
 BuildArchitectures:	noarch
 
 Requires:       yast2-ruby-bindings >= 1.0.0
+Requires:       yast2-configuration-management >= 4.0.4
 
 Summary:	YaST2 - Initial System Configuration
 PreReq:         %fillup_prereq

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,8 @@ client_DATA = \
   clients/firstboot_auto.rb \
   clients/firstboot_hostname.rb \
   clients/firstboot_root.rb \
-  clients/firstboot_user.rb
+  clients/firstboot_user.rb \
+  clients/firstboot_configuration_management.rb
 
 yncludedir = @yncludedir@/firstboot
 ynclude_DATA = \
@@ -42,6 +43,7 @@ fillup_DATA = \
 
 ylibclientdir = "${yast2dir}/lib/y2firstboot/clients"
 ylibclient_DATA = \
+  lib/y2firstboot/clients/configuration_management.rb \
   lib/y2firstboot/clients/root.rb \
   lib/y2firstboot/clients/user.rb
 

--- a/src/clients/firstboot_configuration_management.rb
+++ b/src/clients/firstboot_configuration_management.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2firstboot/clients/configuration_management"
+
+Y2Firstboot::Clients::ConfigurationManagement.new.run

--- a/src/lib/y2firstboot/clients/configuration_management.rb
+++ b/src/lib/y2firstboot/clients/configuration_management.rb
@@ -54,7 +54,7 @@ module Y2Firstboot
       # @return [Yast::ConfigurationManagement::Configurations::Base]
       def config
         settings = Yast::ProductFeatures.GetSection("configuration_management")
-          .merge(FIXED_SETTINGS)
+                                        .merge(FIXED_SETTINGS)
         Yast::ConfigurationManagement::Configurations::Base.import(settings)
       end
     end

--- a/src/lib/y2firstboot/clients/configuration_management.rb
+++ b/src/lib/y2firstboot/clients/configuration_management.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "configuration_management/clients/provision"
+require "configuration_management/configurators/base"
+
+Yast.import "ProductFeatures"
+Yast.import "PackageSystem"
+
+module Y2Firstboot
+  module Clients
+    # This client is meant to be used in firstboot
+    class ConfigurationManagement
+      # Runs the client
+      def run
+        configurator = Yast::ConfigurationManagement::Configurators::Base.for(config)
+        return :abort unless configurator.prepare
+        if !Yast::PackageSystem.CheckAndInstallPackages(configurator.packages.fetch("install", []))
+          return :abort
+        end
+        Yast::ConfigurationManagement::Clients::Provision.new.run
+        :next
+      end
+
+    private
+
+      # @return [Hash] Default settings
+      FIXED_SETTINGS = { "type" => "salt", "mode" => "masterless" }.freeze
+
+      # Returns the configuration management configuration
+      #
+      # It relies in the configuration found in the control file.
+      #
+      # @return [Yast::ConfigurationManagement::Configurations::Base]
+      def config
+        settings = Yast::ProductFeatures.GetSection("configuration_management")
+          .merge(FIXED_SETTINGS)
+        Yast::ConfigurationManagement::Configurations::Base.import(settings)
+      end
+    end
+  end
+end

--- a/src/lib/y2firstboot/clients/configuration_management.rb
+++ b/src/lib/y2firstboot/clients/configuration_management.rb
@@ -38,12 +38,13 @@ module Y2Firstboot
           return :abort
         end
         Yast::ConfigurationManagement::Clients::Provision.new.run
-        :next
+        :auto
       end
 
     private
 
-      # @return [Hash] Default settings
+      # @return [Hash] Fixed settings (these settings cannot be overriden as this is the only
+      #   supported scenario)
       FIXED_SETTINGS = { "type" => "salt", "mode" => "masterless" }.freeze
 
       # Returns the configuration management configuration

--- a/src/lib/y2firstboot/clients/root.rb
+++ b/src/lib/y2firstboot/clients/root.rb
@@ -26,6 +26,7 @@ Yast.import "UsersSimple"
 
 module Y2Firstboot
   module Clients
+    # Client to set the root password
     class Root < Yast::Client
       def run
         dialog_result = Yast::InstRootFirstDialog.new.run

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -28,8 +28,8 @@ Yast.import "Progress"
 
 module Y2Firstboot
   module Clients
+    # Client to set up the first user
     class User < Yast::Client
-
       def initialize
         Yast.include self, "users/routines.rb"
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,49 @@
+srcdir = File.expand_path("../../src", __FILE__)
+y2dirs = ENV.fetch("Y2DIR", "").split(":")
+ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
+
+require "yast"
+require "pathname"
+
+TESTS_PATH = Pathname.new(File.dirname(__FILE__))
+FIXTURES_PATH = TESTS_PATH.join("fixtures")
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  # for coverage we need to load all ruby files
+  src_location = File.expand_path("../../src", __FILE__)
+  Dir["#{src_location}/{module,lib}/**/*.rb"].each { |f| require_relative f }
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+end

--- a/test/y2firstboot/clients/configuration_management_test.rb
+++ b/test/y2firstboot/clients/configuration_management_test.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firstboot/clients/configuration_management"
+require "configuration_management/configurators/salt"
+
+describe Y2Firstboot::Clients::ConfigurationManagement do
+  subject(:client) { described_class.new }
+
+  describe "#run" do
+    let(:provisioner) do
+      instance_double(Yast::ConfigurationManagement::Clients::Provision, run: nil)
+    end
+    let(:configurator) do
+      instance_double(
+        Yast::ConfigurationManagement::Configurators::Salt, prepare: true, packages: packages
+      )
+    end
+    let(:packages) { { "install" => ["salt"] } }
+    let(:settings) { { "states_roots" => ["/srv/salt"] } }
+
+    before do
+      allow(Yast::ProductFeatures).to receive(:GetSection)
+        .with("configuration_management")
+        .and_return(settings)
+      allow(Yast::ConfigurationManagement::Configurators::Base).to receive(:for)
+        .and_return(configurator)
+      allow(Yast::ConfigurationManagement::Clients::Provision).to receive(:new)
+        .and_return(provisioner)
+      allow(Yast::PackageSystem).to receive(:CheckAndInstallPackages).and_return(true)
+    end
+
+    it "uses the configuration from the control file" do
+      expect(Yast::ConfigurationManagement::Configurators::Base).to receive(:for) do |config|
+        expect(config.states_roots).to include(Pathname.new("/srv/salt"))
+        configurator
+      end
+      client.run
+    end
+
+    it "runs the configuration management system" do
+      expect(provisioner).to receive(:run)
+      client.run
+    end
+
+    it "ensures that needed packages are installed" do
+      expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages).with(["salt"])
+        .and_return(true)
+      client.run
+    end
+
+    it "returns :next" do
+      expect(client.run).to eq(:next)
+    end
+
+    context "when type or mode are specified in the configuration" do
+      let(:settings) { { "type" => "puppet", "mode" => "client" } }
+
+      it "forces type and mode" do
+        expect(Yast::ConfigurationManagement::Configurators::Base).to receive(:for)
+          .with(an_object_having_attributes(type: "salt", mode: :masterless))
+          .and_return(configurator)
+        client.run
+      end
+    end
+
+    context "when no settings are specified" do
+      let(:settings) { {} }
+
+      it "uses the default configuration" do
+        expect(Yast::ConfigurationManagement::Configurators::Base).to receive(:for)
+          .with(an_object_having_attributes(type: "salt")).and_return(configurator)
+        client.run
+      end
+    end
+  end
+end

--- a/test/y2firstboot/clients/configuration_management_test.rb
+++ b/test/y2firstboot/clients/configuration_management_test.rb
@@ -69,8 +69,8 @@ describe Y2Firstboot::Clients::ConfigurationManagement do
       client.run
     end
 
-    it "returns :next" do
-      expect(client.run).to eq(:next)
+    it "returns :auto" do
+      expect(client.run).to eq(:auto)
     end
 
     context "when type or mode are specified in the configuration" do


### PR DESCRIPTION
Add integration with the `yast2-configuration-management module`.

- [x] Initialize and call required client.
- [x] Document and extend the schema (see https://github.com/yast/yast-installation-control/pull/76).
- [x] Skip formulas selection