### PR TITLE
[Backport] Fix the example file

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -107,16 +107,6 @@
                     <name>firstboot_welcome</name>
                 </module>
                 <module>
-                    <label>License Agreements</label>
-                    <enabled config:type="boolean">false</enabled>
-                    <name>firstboot_licenses</name>
-                </module>
-                <module>
-                    <label>License Agreement</label>
-                    <enabled config:type="boolean">true</enabled>
-                    <name>firstboot_license_novell</name>
-                </module>
-                <module>
                     <label>License Agreement</label>
                     <enabled config:type="boolean">true</enabled>
                     <name>firstboot_license</name>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 10 07:05:14 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Disable duplicate license dialogs (boo#1131301)
+- Initialize product in firstboot (boo#1132189)
+- 3.1.21
+
+-------------------------------------------------------------------
 Wed Aug  8 09:14:49 UTC 2018 - knut.anderssen@suse.com
 
 - Import missing GetInstArgs module in firstboot_write client

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.20
+Version:        3.1.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firstboot.rb
+++ b/src/clients/firstboot.rb
@@ -32,6 +32,7 @@ module Yast
       Yast.import "Directory"
       Yast.import "Mode"
       Yast.import "Stage"
+      Yast.import "Product"
       Yast.import "ProductControl"
       Yast.import "Wizard"
       Yast.import "Report"
@@ -60,6 +61,8 @@ module Yast
       # initialize package callbacks, since some of the modules run in the
       # firstboot workflow expect them to be initialized (bug #335979)
       PackageCallbacksInit.InitPackageCallbacks
+
+      UI.SetProductName(Product.name)
 
       @ret = ProductControl.Run
       Builtins.y2milestone("ProductControl::Run() returned: %1", @ret)


### PR DESCRIPTION
This is a backport of #63 

---

## Problem

> the default example configuration provided at `/etc/YaST2/firstboot.xml`.file includes two steps asking for license approval

Actually, the workflow section of this **example** file includes three modules for the license agreement, one of them disabled:

* [firstboot_license](https://github.com/yast/yast-firstboot/blob/7303500f54694f8f2339c270d44b5e8e825a94e3/control/firstboot.xml#L119-L123) - enabled
* [firstboot_license_novell](https://github.com/yast/yast-firstboot/blob/7303500f54694f8f2339c270d44b5e8e825a94e3/control/firstboot.xml#L114-L118) - disabled
* [firstboot_licenses](https://github.com/yast/yast-firstboot/blob/7303500f54694f8f2339c270d44b5e8e825a94e3/control/firstboot.xml#L109-L113) - enabled

The problem is that

> QA has started to test YaST Firstboot. But they are not configuring it before executing it. They are just triggering the module with the example configuration provided at `/etc/YaST2/firstboot.xml` [...] which is producing a lot of confusion among the testers.

However, it seems that in a real deployment **this file should be previously customized** according to needed requirements. But, after reading the documentation it could be understood that it is ready to be used, 

> [...] the firstboot installation workflow may involve several different components. Customizing them is optional. If you do not make any changes, firstboot performs the installation using the default settings  — http://docserv.nue.suse.com/documents/SLES_12/SLES-deployment/html/cha.deployment_firstboot.html#sec.fb.customize


#### Related links

* https://bugzilla.suse.com/show_bug.cgi?id=1131327
* https://bugzilla.suse.com/show_bug.cgi?id=1131301
* https://trello.com/c/I2ViMZhi/904-3-sles12-sp5-p2-1131327-build-0134-default-example-firstbootxml-includes-two-steps-asking-for-license-approval


## Solution

To provide a more reasonable `firstboot.xml` to avoid the same again.

