### PR TITLE
Drop automatic configuration references

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -30,35 +30,6 @@
 	For more variables that can be in this section, look into the control file
 	(/etc/YaST2/control.xml or root directory of installation media)
 	-->
-
-	<!--
-	Definition of Automatic Configuration Steps follows - each step
-	runs non-interactive configuration. To enable steps defined in
-	Automatic Configuration, enable inst_automatic_configuration in the
-	workflow.
-	-->
-	<automatic_configuration config:type="list">
-	    <!-- Configure network -->
-	    <ac_step>
-		<text_id>ac_label_1</text_id>
-		<icon>yast-lan</icon>
-		<type>proposals</type>
-		<ac_items config:type="list">
-		    <ac_item>lan</ac_item>
-		</ac_items>
-	    </ac_step>
-	    <!--
-	    Configure printer (needs configured network for net-detection)
-	    -->
-	    <ac_step>
-		<text_id>ac_label_2</text_id>
-		<icon>yast-hwinfo</icon>
-		<type>proposals</type>
-		<ac_items config:type="list">
-		    <ac_item>printer</ac_item>
-		</ac_items>
-	    </ac_step>
-	</automatic_configuration>
     </globals>
     <proposals config:type="list">
         <proposal>

--- a/doc/firstboot-section_mod.xml
+++ b/doc/firstboot-section_mod.xml
@@ -216,23 +216,6 @@
 	variable in /etc/sysconfig/firstboot.
 	</para>
       </section>
-      <section>
-        <title>Using Automatic Configuration</title>
-	<para>
-	Since openSUSE11.0, installer does most part of the system configuration
-	automatically, without user interaction. This feature is also available
-	in firstboot stage. If you have the system installed and only partially
-	configured (e.g. because of different hardware on your computers),
-	enable inst_automatic_configuration step in the firstboot workflow.
-	In the "globals" section of your workflow description file
-	(firstboot.xml), define the steps that should be part of the
-	Automatic Configuration process.
-	</para>
-	<para>
-	For detailed information, see "Automatic Configuration" section of
-	<filename>/usr/share/doc/packages/yast2-installation/control-doc/index.html</filename> file, part of yast2-installation-devel-doc package.
-	</para>
-      </section>
     </section>
     <section>
       <title>Scripting</title>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul  3 10:58:27 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove the references to the already dropped automatic
+  configuration feature (FATE#314695).
+- 4.0.8
+
+-------------------------------------------------------------------
 Mon May 13 11:31:56 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Update the firstboot.xml template to use the "firstboot_licenses"

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.0.7
+Version:        4.0.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
This feature was dropped by the end of 2013, according to commit yast/yast-installation@c234bed.