### PR TITLE
Fix reference to dropped DNS.proposal_valid method

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 15 16:05:34 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not rely on the already dropped DNS.proposal_valid method
+  (related to bsc#1140199).
+- 4.1.8
+
+-------------------------------------------------------------------
 Mon May 13 11:31:56 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Update the firstboot.xml template to use the "firstboot_licenses"

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.1.7
+Version:        4.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firstboot_hostname.rb
+++ b/src/clients/firstboot_hostname.rb
@@ -29,6 +29,19 @@ module Yast
   # YaST2-Network when the second stage was removed from the installation
   # process
   class FirstbootHostnameClient < Client
+    class << self
+      # @!method valid_dns_proposal=(value)
+      #   @param [Boolean] Whether a valid DNS proposal was done
+      attr_writer :valid_dns_proposal
+
+      # Determines whether a valid DNS proposal was done
+      #
+      # @return [Boolean] Returns true if a DNS proposal was done
+      def valid_dns_proposal
+        @valid_dns_proposal ||= false
+      end
+    end
+
     def main
       Yast.import "UI"
 
@@ -48,7 +61,7 @@ module Yast
 
       # only once, do not re-propose if user gets back to this dialog from
       # the previous screen - bnc#438124
-      if !DNS.proposal_valid
+      if !self.class.valid_dns_proposal
         DNS.Read # handles NetworkConfig too
         DNS.ProposeHostname # generate random hostname, if none known so far
 
@@ -68,7 +81,7 @@ module Yast
         Host.Write
 
         # do not let Lan override us, #152218
-        DNS.proposal_valid = true
+        self.class.valid_dns_proposal = true
 
         # In InstHostname writing was delayed to do it with the rest of
         # network configuration in lan_proposal.

--- a/src/clients/firstboot_hostname.rb
+++ b/src/clients/firstboot_hostname.rb
@@ -107,9 +107,8 @@ module Yast
         Frame(
           _("Hostname and Domain Name"),
           VBox(
-            HBox("HOSTNAME", HSpacing(1), "DOMAIN"),
-            Left("DHCP_HOSTNAME"),
-            Left("WRITE_HOSTNAME")
+            Left("HOSTNAME"),
+            Left("DHCP_HOSTNAME")
           )
         )
       )
@@ -125,7 +124,7 @@ module Yast
         "disable_buttons"    => GetInstArgs.enable_back ? [] : ["back_button"]
       )
 
-        if ret == :next
+      if ret == :next
         # Pre-populate resolv.conf search list with current domain name
         # but only if none exists so far
         current_domain = Ops.get_string(@hn_settings, "DOMAIN", "")


### PR DESCRIPTION
Fixes a problem caused after dropping the [DNS.proposal_valid method](https://github.com/yast/yast-network/commit/f33a2fa0073b27a93ffe1940de234b3fa2109086).

Additionally, a problem with the dialog has been fixed, as you can see in the following screenshots.

## Before

![firstboot-hostname-broken](https://user-images.githubusercontent.com/15836/61280139-47f71000-a7af-11e9-823b-b98609ee61b0.png)

## Now

![firstboot-hostname-ok](https://user-images.githubusercontent.com/15836/61280148-4c232d80-a7af-11e9-9e82-96d01d8249d9.png)
