### PR TITLE
Allow to specify the license location via directory argument

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Dec 13 00:11:32 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the "firstboot_licenses" client to give precedence to
+  the directory argument, allowing to use it multiple times to show
+  different licenses (bsc#1154708).
+- 3.1.25
+
+-------------------------------------------------------------------
 Mon Nov 18 16:17:36 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add firstboot.rnc to the desktop file (related to bsc#1156905).

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.24
+Version:        3.1.25
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firstboot/clients/licenses.rb
+++ b/src/lib/y2firstboot/clients/licenses.rb
@@ -53,7 +53,7 @@ module Y2Firstboot
       def inst_license_args
         args = GetInstArgs.argmap
         args["action"] = refusal_action
-        args["directories"] = licenses_directories
+        args["directories"] = licenses_directories if args["directory"].to_s.empty?
 
         Builtins.y2milestone("inst_license options: %1", args)
 
@@ -69,9 +69,9 @@ module Y2Firstboot
 
       # Directories in which look for the license agreement texts
       #
-      # NOTE: if that result in an empty list, {Yast::InstLicenseClient} will do
-      # an extra attemp to look for the license agreement in the path given as
-      # "base_product_license_directory" global param through the control file.
+      # NOTE: if that result in an empty list and the "directory" argument was ommited too,
+      # {Yast::InstLicenseClient} will do an extra attemp to look for the license agreement in the
+      # path given as "base_product_license_directory" global param through the control file.
       #
       # @return [Array<String>] license agreement paths
       def licenses_directories

--- a/src/lib/y2firstboot/clients/licenses.rb
+++ b/src/lib/y2firstboot/clients/licenses.rb
@@ -35,6 +35,8 @@ module Y2Firstboot
     class Licenses < Yast::Client
       def initialize
         textdomain "firstboot"
+
+        @args = GetInstArgs.argmap
       end
 
       def run
@@ -45,15 +47,16 @@ module Y2Firstboot
         result
       end
 
-    private
+      private
+
+      attr_accessor :args
 
       # Build, log, and returns args to be used for calling InstLicense client
       #
       # @return [Array]
       def inst_license_args
-        args = GetInstArgs.argmap
         args["action"] = refusal_action
-        args["directories"] = licenses_directories if args["directory"].to_s.empty?
+        args["directories"] = directories
 
         Builtins.y2milestone("inst_license options: %1", args)
 
@@ -69,12 +72,35 @@ module Y2Firstboot
 
       # Directories in which look for the license agreement texts
       #
-      # NOTE: if that result in an empty list and the "directory" argument was ommited too,
-      # {Yast::InstLicenseClient} will do an extra attemp to look for the license agreement in the
-      # path given as "base_product_license_directory" global param through the control file.
+      # NOTE: if that result in an empty list, {Yast::InstLicenseClient} will do an extra attemp to
+      # look for the license agreement in the path given as "base_product_license_directory" global
+      # param through the control file.
       #
       # @return [Array<String>] license agreement paths
-      def licenses_directories
+      def directories
+        return module_license_directories if module_license_directories.any?
+
+        sysconfig_license_directories
+      end
+
+      # Directories defined by the module arguments
+      #
+      # NOTE: right now license module can only define a directory path, but it could be extended to
+      # support more than one (e.g., by a "directories" list).
+      #
+      # @return [Array<String>] license agreement paths
+      def module_license_directories
+        directories =  [
+          args["directory"]
+        ]
+
+        directories.map(&:to_s).reject(&:empty?)
+      end
+
+      # Directories defined in the sysconfig firstboot file
+      #
+      # @return [Array<String>] license agreement paths
+      def sysconfig_license_directories
         directories = [
           Misc.SysconfigRead(path(".sysconfig.firstboot.FIRSTBOOT_LICENSE_DIR"), ""),
           Misc.SysconfigRead(path(".sysconfig.firstboot.FIRSTBOOT_NOVELL_LICENSE_DIR"), "")

--- a/test/y2firstboot/clients/licenses_test.rb
+++ b/test/y2firstboot/clients/licenses_test.rb
@@ -53,19 +53,16 @@ describe Y2Firstboot::Clients::Licenses do
   describe "#run" do
     context "when 'directory' argument is given" do
       let(:directory) { "/path/to/somewhere" }
-      let(:expected_arg) do
-        { "directories" => [directory] }
-      end
 
-      it "includes it as an argument for InstLicense client" do
+      it "includes it in the 'directories' argument sent to InstLicense client" do
         expect(Yast::WFM).to receive(:CallFunction)
-          .with("inst_license", array_including(hash_including("directory" => directory)))
+          .with("inst_license", array_including(hash_including("directories" => [directory])))
 
         subject.run
       end
     end
 
-    shared_examples "calls client with needed directories" do |*defined_dir|
+    shared_examples "calls client giving the right directories" do |*defined_dir|
       it "includes it in the 'directories' argument sent to InstLicense client" do
         expect(Yast::WFM)
           .to receive(:CallFunction)
@@ -77,15 +74,15 @@ describe Y2Firstboot::Clients::Licenses do
         subject.run
       end
 
-      context "but the 'directory' argument was given" do
+      context "but the 'directory' module argument is given too" do
         let(:directory) { "/path/to/somewhere" }
 
-        it "does not includes it in the 'directories' argument sent to InstLicense client" do
+        it "includes only it in the 'directories' argument sent to InstLicense client" do
           expect(Yast::WFM)
-            .to_not receive(:CallFunction)
+            .to receive(:CallFunction)
             .with(
               "inst_license",
-              array_including(hash_including({ "directories" => defined_dir }))
+              array_including(hash_including({ "directories" => [directory] }))
             )
 
           subject.run
@@ -96,20 +93,20 @@ describe Y2Firstboot::Clients::Licenses do
     context "when FIRSTBOOT_LICENSE_DIR is defined" do
       let(:firstboot_license_dir) { "/path/to/licenses" }
 
-      include_examples "calls client with needed directories", "/path/to/licenses"
+      include_examples "calls client giving the right directories",  "/path/to/licenses"
     end
 
     context "when FIRSTBOOT_NOVELL_LICENSE_DIR is defined" do
       let(:firstboot_novell_license_dir) { "/path/to/novell/licenses" }
 
-      include_examples "calls client with needed directories", "/path/to/novell/licenses"
+      include_examples "calls client giving the right directories",  "/path/to/novell/licenses"
     end
 
     context "when both, FIRSTBOOT_LICENSE_DIR and FIRSTBOOT_NOVELL_LICENSE_DIR, are defined" do
       let(:firstboot_license_dir) { "/p/t/licenses" }
       let(:firstboot_novell_license_dir) { "/p/t/n/licenses" }
 
-      include_examples "calls client with needed directories", "/p/t/licenses", "/p/t/n/licenses"
+      include_examples "calls client giving the right directories", "/p/t/licenses", "/p/t/n/licenses"
     end
   end
 

--- a/test/y2firstboot/clients/licenses_test.rb
+++ b/test/y2firstboot/clients/licenses_test.rb
@@ -26,6 +26,7 @@ require "y2firstboot/clients/licenses"
 describe Y2Firstboot::Clients::Licenses do
   subject(:client) { described_class.new }
 
+  let(:directory) { "" }
   let(:firstboot_license_dir) { "" }
   let(:firstboot_novell_license_dir) { "" }
   let(:client_response) { :whatever }
@@ -44,53 +45,71 @@ describe Y2Firstboot::Clients::Licenses do
 
     allow(Yast::WFM).to receive(:CallFunction)
       .and_return(client_response)
+
+    allow(Yast::GetInstArgs).to receive(:argmap)
+      .and_return({"directory" => directory})
   end
 
   describe "#run" do
-    context "when FIRSTBOOT_LICENSE_DIR is defined" do
-      let(:firstboot_license_dir) { "/path/to/licenses" }
-      let(:firstboot_novell_license_dir) { "" }
+    context "when 'directory' argument is given" do
+      let(:directory) { "/path/to/somewhere" }
       let(:expected_arg) do
-        { "directories" => [firstboot_license_dir] }
+        { "directories" => [directory] }
       end
 
-      it "includes it as arg for InstLicense client" do
+      it "includes it as an argument for InstLicense client" do
         expect(Yast::WFM).to receive(:CallFunction)
-          .with("inst_license", array_including(hash_including(expected_arg)))
+          .with("inst_license", array_including(hash_including("directory" => directory)))
 
         subject.run
       end
+    end
+
+    shared_examples "calls client with needed directories" do |*defined_dir|
+      it "includes it in the 'directories' argument sent to InstLicense client" do
+        expect(Yast::WFM)
+          .to receive(:CallFunction)
+          .with(
+            "inst_license",
+            array_including(hash_including({ "directories" => defined_dir }))
+          )
+
+        subject.run
+      end
+
+      context "but the 'directory' argument was given" do
+        let(:directory) { "/path/to/somewhere" }
+
+        it "does not includes it in the 'directories' argument sent to InstLicense client" do
+          expect(Yast::WFM)
+            .to_not receive(:CallFunction)
+            .with(
+              "inst_license",
+              array_including(hash_including({ "directories" => defined_dir }))
+            )
+
+          subject.run
+        end
+      end
+    end
+
+    context "when FIRSTBOOT_LICENSE_DIR is defined" do
+      let(:firstboot_license_dir) { "/path/to/licenses" }
+
+      include_examples "calls client with needed directories", "/path/to/licenses"
     end
 
     context "when FIRSTBOOT_NOVELL_LICENSE_DIR is defined" do
-      let(:firstboot_license_dir) { "" }
       let(:firstboot_novell_license_dir) { "/path/to/novell/licenses" }
-      let(:expected_arg) do
-        { "directories" => [firstboot_novell_license_dir] }
-      end
 
-      it "includes it as arg for InstLicense client" do
-        expect(Yast::WFM).to receive(:CallFunction)
-          .with("inst_license", array_including(hash_including(expected_arg)))
-
-        subject.run
-      end
+      include_examples "calls client with needed directories", "/path/to/novell/licenses"
     end
 
     context "when both, FIRSTBOOT_LICENSE_DIR and FIRSTBOOT_NOVELL_LICENSE_DIR, are defined" do
-      let(:firstboot_license_dir) { "/path/to/licenses" }
-      let(:firstboot_novell_license_dir) { "/path/to/novell/licenses" }
-      let(:expected_arg) do
-        { "directories" => [firstboot_license_dir, firstboot_novell_license_dir] }
-      end
+      let(:firstboot_license_dir) { "/p/t/licenses" }
+      let(:firstboot_novell_license_dir) { "/p/t/n/licenses" }
 
-      it "includes them as arg for InstLicense client" do
-        # the matcher is also ensuring the right licenses order
-        expect(Yast::WFM).to receive(:CallFunction)
-          .with("inst_license", array_including(hash_including(expected_arg)))
-
-        subject.run
-      end
+      include_examples "calls client with needed directories", "/p/t/licenses", "/p/t/n/licenses"
     end
   end
 


### PR DESCRIPTION
## Problem

After changes made in https://github.com/yast/yast-firstboot/pull/67, it seems that the `Y2Firstboot::Clients::Licenses` client cannot be used to display two (or more) licenses in two (or more) different _pages_. Instead, when the client found more than once valid path to licenses in the firstboot configuration file it will show them together in the same _page_.


* https://bugzilla.novell.com/show_bug.cgi?id=1154708

<details>
<summary>Click to show/hide screenshots</summary>

---
<p align="center"><em>Defined path to licenses in the firstboot configuration file</em></p>

![Screenshot_20191213_033645](https://user-images.githubusercontent.com/1691872/70786176-f4034e00-1d83-11ea-8cbb-bee8c19f10d8.png)

---

<p align="center"><em>Licenses are being shown together</em></p>

![Screenshot_20191213_033330](https://user-images.githubusercontent.com/1691872/70786193-febde300-1d83-11ea-975c-feafde9fa2cd.png)
</details>

## Even using the `directory` argument

```xml
<module>
  <label>SUSE License Agreement</label>
  <enabled config:type="boolean">true</enabled>
  <name>firstboot_licenses</name>
  <arguments>
    <directory>/path/to/SUSE/licenses/dir</directory>
  </arguments>
</module>
```
To use the `directory` argument as above has no effect because `directories` argument is also sent to the `InstLicense` installation client, which [gives precedence to the latter over the former](https://github.com/yast/yast-installation/blob/aa816f10b7fa748eb7aafb9ecbacfbf9b2bab718/src/lib/installation/clients/inst_license.rb#L83-L90).

## Solution

To choose the path(s) to be included in the `directories` argument sent to the `InstLicense` installation client, prioritizing `directory` module argument when present.

## Test

* Unit test updated.
* Also tested manually.

## Screenshots

<details>
<summary>Click to show/hide</summary>

---

<p align="center"><em>The firstboot configuration</em></p>

| /etc/sysconfig/firstboot | /etc/YaST2/firstboot.xml |
| - | - |
| ![Screenshot_20191213_035019](https://user-images.githubusercontent.com/1691872/70786989-b30c3900-1d85-11ea-9dd3-ed91f2ef3943.png) | ![Screenshot_20191213_034719](https://user-images.githubusercontent.com/1691872/70786774-48f39400-1d85-11ea-8fc2-96fae1d89fbf.png) |

---

<p align="center"><em>openSUSE License Agreement</em></p>

![Screenshot_20191213_032758](https://user-images.githubusercontent.com/1691872/70787110-f1095d00-1d85-11ea-8dc1-3270ec0d0b10.png)

---

<p align="center"><em>Partner License Agreement</em></p>

![Screenshot_20191213_032934](https://user-images.githubusercontent.com/1691872/70787127-f8306b00-1d85-11ea-8866-c80425b832e5.png)
</details>


