### PR TITLE
[SLE-12-SP5] Allow to specify the license location via directory argument

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Dec 13 00:11:32 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the "firstboot_licenses" client to give precedence to
+  the directory argument, allowing to use it multiple times to show
+  different licenses (bsc#1154708).
+- 3.1.25
+
+-------------------------------------------------------------------
 Mon Nov 18 16:17:36 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add firstboot.rnc to the desktop file (related to bsc#1156905).

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        3.1.24
+Version:        3.1.25
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
### :memo: The same than #82 but for SLE-12-SP5

---

Summarizing, the `Y2Firstboot::Clients::License` now gives precedence to the `directory` module argument over the sysconfig defined paths.

See the #82 for more details.
