### PR TITLE
[SLE-15-GA] Allow to specify the license location via directory argument

### DIFF
--- a/desktop/firstboot.desktop
+++ b/desktop/firstboot.desktop
@@ -13,7 +13,7 @@ X-SuSE-YaST-AutoInst=all
 X-SuSE-YaST-Geometry=
 X-SuSE-YaST-SortKey=
 X-SuSE-YaST-AutoInstDataType=map
-X-SuSE-YaST-AutoInstSchema=
+X-SuSE-YaST-AutoInstSchema=firstboot.rnc
 
 Exec=
 Icon=yast-firstboot

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Fri Dec 13 00:11:32 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the "firstboot_licenses" client to give precedence to
+  the directory argument, allowing to use it multiple times to show
+  different licenses (bsc#1154708).
+- 4.0.10
+
+-------------------------------------------------------------------
+Mon Nov 18 16:17:36 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add firstboot.rnc to the desktop file (related to bsc#1156905).
+- 4.0.9
+
+-------------------------------------------------------------------
 Wed Jul  3 10:58:27 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Remove the references to the already dropped automatic

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.0.8
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
### :memo: The same than #82 but for SLE-15-GA

---

Summarizing, the `Y2Firstboot::Clients::License` now gives precedence to the `directory` module argument over the sysconfig defined paths.

See the #82 for more details.