### PR TITLE
[SLE-15-SP1] Allow to specify the license location via directory argument

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -30,35 +30,6 @@
 	For more variables that can be in this section, look into the control file
 	(/etc/YaST2/control.xml or root directory of installation media)
 	-->
-
-	<!--
-	Definition of Automatic Configuration Steps follows - each step
-	runs non-interactive configuration. To enable steps defined in
-	Automatic Configuration, enable inst_automatic_configuration in the
-	workflow.
-	-->
-	<automatic_configuration config:type="list">
-	    <!-- Configure network -->
-	    <ac_step>
-		<text_id>ac_label_1</text_id>
-		<icon>yast-lan</icon>
-		<type>proposals</type>
-		<ac_items config:type="list">
-		    <ac_item>lan</ac_item>
-		</ac_items>
-	    </ac_step>
-	    <!--
-	    Configure printer (needs configured network for net-detection)
-	    -->
-	    <ac_step>
-		<text_id>ac_label_2</text_id>
-		<icon>yast-hwinfo</icon>
-		<type>proposals</type>
-		<ac_items config:type="list">
-		    <ac_item>printer</ac_item>
-		</ac_items>
-	    </ac_step>
-	</automatic_configuration>
     </globals>
     <proposals config:type="list">
         <proposal>

--- a/doc/firstboot-section_mod.xml
+++ b/doc/firstboot-section_mod.xml
@@ -216,23 +216,6 @@
 	variable in /etc/sysconfig/firstboot.
 	</para>
       </section>
-      <section>
-        <title>Using Automatic Configuration</title>
-	<para>
-	Since openSUSE11.0, installer does most part of the system configuration
-	automatically, without user interaction. This feature is also available
-	in firstboot stage. If you have the system installed and only partially
-	configured (e.g. because of different hardware on your computers),
-	enable inst_automatic_configuration step in the firstboot workflow.
-	In the "globals" section of your workflow description file
-	(firstboot.xml), define the steps that should be part of the
-	Automatic Configuration process.
-	</para>
-	<para>
-	For detailed information, see "Automatic Configuration" section of
-	<filename>/usr/share/doc/packages/yast2-installation/control-doc/index.html</filename> file, part of yast2-installation-devel-doc package.
-	</para>
-      </section>
     </section>
     <section>
       <title>Scripting</title>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Fri Dec 13 00:11:32 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the "firstboot_licenses" client to give precedence to
+  the directory argument, allowing to use it multiple times to show
+  different licenses (bsc#1154708).
+- Add firstboot.rnc to the desktop file (related to bsc#1156905).
+- Remove the references to the already dropped automatic
+  configuration feature (FATE#314695).
+- 4.1.9
+
+-------------------------------------------------------------------
 Mon Jul 15 16:05:34 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not rely on the already dropped DNS.proposal_valid method

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.1.8
+Version:        4.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firstboot/clients/licenses.rb
+++ b/src/lib/y2firstboot/clients/licenses.rb
@@ -47,7 +47,7 @@ module Y2Firstboot
         result
       end
 
-      private
+    private
 
       attr_accessor :args
 
@@ -90,7 +90,7 @@ module Y2Firstboot
       #
       # @return [Array<String>] license agreement paths
       def module_license_directories
-        directories =  [
+        directories = [
           args["directory"]
         ]
 

--- a/test/y2firstboot/clients/licenses_test.rb
+++ b/test/y2firstboot/clients/licenses_test.rb
@@ -47,7 +47,7 @@ describe Y2Firstboot::Clients::Licenses do
       .and_return(client_response)
 
     allow(Yast::GetInstArgs).to receive(:argmap)
-      .and_return({"directory" => directory})
+      .and_return("directory" => directory)
   end
 
   describe "#run" do
@@ -68,7 +68,7 @@ describe Y2Firstboot::Clients::Licenses do
           .to receive(:CallFunction)
           .with(
             "inst_license",
-            array_including(hash_including({ "directories" => defined_dir }))
+            array_including(hash_including("directories" => defined_dir))
           )
 
         subject.run
@@ -82,7 +82,7 @@ describe Y2Firstboot::Clients::Licenses do
             .to receive(:CallFunction)
             .with(
               "inst_license",
-              array_including(hash_including({ "directories" => [directory] }))
+              array_including(hash_including("directories" => [directory]))
             )
 
           subject.run
@@ -91,22 +91,22 @@ describe Y2Firstboot::Clients::Licenses do
     end
 
     context "when FIRSTBOOT_LICENSE_DIR is defined" do
-      let(:firstboot_license_dir) { "/path/to/licenses" }
+      let(:firstboot_license_dir) { "/path/to/license" }
 
-      include_examples "calls client giving the right directories",  "/path/to/licenses"
+      include_examples "calls client giving the right directories", "/path/to/license"
     end
 
     context "when FIRSTBOOT_NOVELL_LICENSE_DIR is defined" do
-      let(:firstboot_novell_license_dir) { "/path/to/novell/licenses" }
+      let(:firstboot_novell_license_dir) { "/path/to/novell/license" }
 
-      include_examples "calls client giving the right directories",  "/path/to/novell/licenses"
+      include_examples "calls client giving the right directories", "/path/to/novell/license"
     end
 
     context "when both, FIRSTBOOT_LICENSE_DIR and FIRSTBOOT_NOVELL_LICENSE_DIR, are defined" do
-      let(:firstboot_license_dir) { "/p/t/licenses" }
-      let(:firstboot_novell_license_dir) { "/p/t/n/licenses" }
+      let(:firstboot_license_dir) { "/p/t/license" }
+      let(:firstboot_novell_license_dir) { "/p/t/n/license" }
 
-      include_examples "calls client giving the right directories", "/p/t/licenses", "/p/t/n/licenses"
+      include_examples "calls client giving the right directories", "/p/t/license", "/p/t/n/license"
     end
   end
 


### PR DESCRIPTION
### :memo: The same than #82 but for SLE-15-GA

---

Summarizing, the `Y2Firstboot::Clients::License` now gives precedence to the `directory` module argument over the sysconfig defined paths.

See the #82 for more details.