### PR TITLE
Update spelling of SUSE (bsc#970809)

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 18 15:42:53 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Replace outdated "SuSE" spelling (bsc#970809).
+- 4.2.6
+
+-------------------------------------------------------------------
 Fri Dec 13 00:11:32 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Improve the "firstboot_licenses" client to give precedence to

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/clients/firstboot_finish.rb
+++ b/src/clients/firstboot_finish.rb
@@ -76,11 +76,11 @@ module Yast
           "<p>The installation of &product; on your machine is complete.\nAfter clicking <b>Finish</b>, you can log in to the system.</p>\n"
         ) +
         # congratulation text 3/4
-        # Translators: If there exists a SuSE web-page for your language
+        # Translators: If there exists a SUSE web-page for your language
         # change the address accordingly. If in doubt leave the original.
         _("<p>Visit us at www.suse.com.</p>") +
         # congratulation text 4/4
-        _("<p>Have a lot of fun!<br>Your SuSE Development Team</p>")
+        _("<p>Have a lot of fun!<br>Your SUSE Development Team</p>")
 
 
       # If text exists, read it from file instead; it is expected to be richtext.
@@ -118,7 +118,7 @@ module Yast
         _(
           "<p>If you choose the default graphical desktop KDE, you can\n" +
             "adjust some KDE settings to your hardware. Also notice\n" +
-            "our SuSE Welcome Dialog.</p>\n"
+            "our SUSE Welcome Dialog.</p>\n"
         )
 
       if Firstboot.show_y2cc_checkbox
@@ -126,7 +126,7 @@ module Yast
         @help = Ops.add(
           @help,
           _(
-            "<p>If desired, experts can use the full range of SuSE's configuration\n" +
+            "<p>If desired, experts can use the full range of SUSE's configuration\n" +
               "modules at this time. Check <b>Start YaST Control Center</b> and it will start\n" +
               "after <b>Finish</b>. Note: The Control Center does not have a back button to\n" +
               "return to this installation sequence.</p>\n"


### PR DESCRIPTION
[bsc#970809](https://bugzilla.suse.com/show_bug.cgi?id=970809) was reported a long time ago pointing that the old "SuSE" spelling was still used in some parts of YaST.

After checking the whole current YaST codebase, turns out that nowadays the only occurrences were in yast-firstboot.

This pull request fixes that. After merging it, there should be no more mentions to SuSE anywhere in YaST.