### PR TITLE
Fix packaging error (bsc#1161224)

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 21 10:56:58 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fix packaging error (bsc#1161224)
+- 4.2.10
+
+-------------------------------------------------------------------
 Tue Jan 14 11:02:28 UTC 2020 - Ludwig Nussel <lnussel@suse.de>
 
 - Don't use deprecated Progress.on

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.2.8
+Version:        4.2.10
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ fillup_DATA = \
 ylibclientdir = "${yast2dir}/lib/y2firstboot/clients"
 ylibclient_DATA = \
   lib/y2firstboot/clients/configuration_management.rb \
+  lib/y2firstboot/clients/firstboot_ssh.rb \
   lib/y2firstboot/clients/root.rb \
   lib/y2firstboot/clients/user.rb \
   lib/y2firstboot/clients/licenses.rb


### PR DESCRIPTION
This pull request introduced the file `src/lib/y2firstboot/clients/firstboot_ssh.rb`, but it was not added to the corresponding Makefile:
https://github.com/yast/yast-firstboot/pull/89

As a result, we got this bug report (and some duplicate reports):
https://bugzilla.suse.com/show_bug.cgi?id=1161224

This should fix it.