### PR TITLE
Fix example

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -158,7 +158,7 @@
                     <label>Finish Setup</label>
                     <name>inst_congratulate</name>
                     <enable_back>no</enable_back>
-                    <enable_next>no</enable_next>
+                    <enable_next>yes</enable_next>
                 </module>
 
             </modules>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 13:28:25 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix disabled finish button (bsc#1163100)
+- 4.2.11
+
+-------------------------------------------------------------------
 Tue Jan 21 10:56:58 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fix packaging error (bsc#1161224)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST


### PR DESCRIPTION
trello: https://trello.com/c/EZcJWlvG/1657-sle15-sp1-p2-1163100-inactive-back-and-finish-buttons-in-yast2-firstboot
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1163100