### PR TITLE
Fix language keyboard

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Mar 13 13:15:39 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
-- remember correctly keyboard if setting in keyboard language
-  screen setting first keyboard and then language (bsc#1160164)
+- remember the keyboard selection in the keyboard language dialog
+  when the language is selected after the keyboard (bsc#1160164)
 - 4.2.12
 
 -------------------------------------------------------------------

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 13 13:15:39 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- remember correctly keyboard if setting in keyboard language
+  screen setting first keyboard and then language (bsc#1160164)
+- 4.2.12
+
+-------------------------------------------------------------------
 Wed Feb 26 13:28:25 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix disabled finish button (bsc#1163100)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/clients/firstboot_language_keyboard.rb
+++ b/src/clients/firstboot_language_keyboard.rb
@@ -172,6 +172,8 @@ module Yast
           break
         elsif @ret == :keyboard
           Keyboard.user_decision = true
+          # store keyboard selection to survive even redraw (bsc#1160164)
+          Keyboard.Set(UI.QueryWidget(Id(:keyboard), :Value) || "")
         elsif @ret == :next || @ret == :language
           @language = Convert.to_string(UI.QueryWidget(Id(:language), :Value))
           @keyboard = Convert.to_string(UI.QueryWidget(Id(:keyboard), :Value))


### PR DESCRIPTION
trello: https://trello.com/c/a0e0DCMO/1595-ostumbleweed-p5-1160164-build-20200105-openqa-test-fails-in-yast2firstboot-wrong-language-for-input

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1160164

for issue descripton see bugzilla.

Solution, remember user selection for keyboard.