### PR TITLE
Recommend icewm if graphical installation (bsc#1165646)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-firstboot-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 --privileged -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-firstboot-image yast-travis-ruby

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  8 15:15:32 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Recommend icewm if graphical installation (bsc#1165646)
+- 4.2.14
+
+-------------------------------------------------------------------
 Tue Mar 17 17:17:22 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Enable by default registration on SLE (bsc#1162846)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -43,6 +43,9 @@ Requires:       yast2-network >= 4.2.14
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-configuration-management >= 4.1.3
 
+# bsc #1165646
+Recommends:     (icewm if libyui-qt)
+
 BuildArch:      noarch
 
 %description

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1165646

## Symptom

OpenQA cannot reliably detect certain pop-up dialogs such as the warning that a password is not strong enough when a "yast-firstboot" workflow is running (with the Qt UI): It is expected in the center of the screen. But sometimes it is at the top left corner, sometimes it is completely missing.


## Problem

No window manager is running because some software patterns don't install the one that we expect for that scenario: _icewm_.

This yast-firstboot wizard is running as a separate X11 session before the actual desktop (GNOME in this case) is running. It uses _testX_ (a leftover from old _sax2_) to try to start an X server, which in turn tries to start _icewm_ as a window manager.

In this scenario, it can start an X server, but _icewm_ is simply not installed, so it cannot be started. That means that there is no window manager running in that yast-firstboot X session, so pop-up windows are not centered or really managed in any way (there are also no WM decorations like a title bar or borders). Sometimes the window stacking order may also be wrong, so a pop-up window may appear _behind_ the main window, making it unaccessible, and the user cannot continue (Alt-Tab will also not work then because this also would require a window manager).

## Solution

Make sure we have a window manager (but only if this was a graphical installation; we don't need or want one for an NCurses installation).

This commit only recommends installing _icewm_, and only if _libyui-qt_ is also installed.

## Remaining Risks

There may be pathological cases where this may also not work, such as the user explicitly deselecting _libyui-qt_ or _icewm_. This is still okay: The workflow will generally remain usable, albeit not quite as nicely usable.

There is a remote chance that a pop-up window may end up behind the main window in such a case; but only if there is such an error (caused by user actions) in the first place that causes such a pop-up dialog, and then only in rare cases.

This is a pragmatic solution, not a 100% perfect one. But it leaves some room for the user to override getting _icewm_ installed if that is his preference.


## Target Release

The bug was filed against Tumbleweed, but this may also happen in SLE-15 (-SP2). While this would certainly not warrant a backport to SLE-15 GA or -SP1, SP2 might be worth being considered.

Update 2020-08-04 17:00:
@jsrain  says he wants it in SLE-15-SP2 as well.

## Affected Users / Scenarios

Only when yast-firstboot is used at all, of course, which is not that common.

Normal default installations are not affected; AutoYaST installations might be, business products with a separate config workflow that is executed in a custom yast-firstboot as well.