### PR TITLE
Fallback to default language when locale.conf is still not configured

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul  1 14:45:53 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Adapted the "language_keyboard" client using the default language
+  as a fallback when it tries to read the system locale but it is
+  not configured yet (bsc#1173498)
+- 4.1.10
+
+-------------------------------------------------------------------
 Fri Dec 13 00:11:32 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Improve the "firstboot_licenses" client to give precedence to

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -29,8 +29,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 
 # yast2/NeworkDevices -> yast2/NetworkInterfaces
 Requires:	yast2 >= 2.16.23
-# Language::SwitchToEnglishIfNeeded
-Requires:	yast2-country >= 2.19.5
+# Language::default_language
+Requires:	yast2-country >= 4.1.16
 # Rely on the YaST2-Firstboot.service for halting the system on failure
 Requires:	yast2-installation >= 4.1.2
 # network autoconfiguration

--- a/src/clients/firstboot_language_keyboard.rb
+++ b/src/clients/firstboot_language_keyboard.rb
@@ -232,6 +232,9 @@ module Yast
       if ret == :next
         Keyboard.Set(@keyboard)
 
+        # Store the current default before set it. Used as a fallback in case
+        # that there is no locale configured yet (bsc#1173498)
+        default_language = Language.default_language
         # Language has been set already.
         # On first run store users decision as default.
         Builtins.y2milestone("Resetting to default language")
@@ -258,7 +261,7 @@ module Yast
 
         # install language dependent packages now
         # Language::PackagesModified () does not work here as _on_entry variables are not set
-        if @language != Language.ReadLocaleConfLanguage
+        if @language != (Language.ReadLocaleConfLanguage || default_language)
           if !Language.PackagesInit([@language])
             # error message
             Report.Error(


### PR DESCRIPTION
## Problem

When running the firstboot without a configured locale, it tries to install the translations for the default language even without modifying the default selection.

- https://bugzilla.suse.com/show_bug.cgi?id=1173498

## Solution

Use the default language as a fallback when the system locale has not been assigned yet.

Needs yast/yast-country#255

**Note:** This does not solve the report of the error when there are not sources available but the package is already installed which should be handled by a different PR.