### PR TITLE
Use wizard layout

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -10,6 +10,11 @@
 
     <textdomain>firstboot</textdomain>
 
+	<!---
+	See https://github.com/yast/yast-installation/blob/master/doc/control-file.md for more
+	explanation about the control file settings.
+	-->
+
     <globals>
 
 	<!--
@@ -26,9 +31,18 @@
 	<!-- The default value of "Automatic Login" checkbox -->
 	<enable_autologin config:type="boolean">false</enable_autologin>
 
+	<!-- This option is deprecated in favor of installation-layout -->
+	<!-- <installation_ui>sidebar</installation_ui> -->
+
+	<!-- Configuration of the installation/firstboot layout -->
+	<installation_layout>
+		<mode>steps</mode>
+		<banner config:type="boolean">false</banner>
+	</installation_layout>
+
 	<!--
 	For more variables that can be in this section, look into the control file
-	(/etc/YaST2/control.xml or root directory of installation media)
+	(/etc/YaST2/control.xml or root directory of installation media).
 	-->
     </globals>
     <proposals config:type="list">

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 23 14:27:02 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Configure the wizard layout according to the product features.
+- Related to jsc#PM-1998.
+- 4.3.2
+
+-------------------------------------------------------------------
 Thu Jul 16 09:15:57 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix firsboot_hostname client crash (bsc#1173298)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -32,8 +32,8 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  ruby
 
 PreReq:         %fillup_prereq
-# yast2/NeworkDevices -> yast2/NetworkInterfaces
-Requires:       yast2 >= 2.16.23
+# UI::Wizards::Layout
+Requires:       yast2 >= 4.3.16
 # Language::SwitchToEnglishIfNeeded
 Requires:       yast2-country >= 2.19.5
 # Rely on the YaST2-Firstboot.service for halting the system on failure

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST


### PR DESCRIPTION
## Problem

YaST installer and YaST Firstboot look very different because they are using different layout configuration.

YaST Firstboot always forces the same layout (left sidebar with steps and no top banner).

* Part of https://trello.com/c/cWUeijfl/1962-2-round-unify-firstboot-look-and-feel-with-installer
* Related to https://jira.suse.com/browse/PM-1998

## Solution

There is a new helper class (`UI::Wizards::Layout`) provided by *yast2* that allows to configure the layout according to the control file settings. That class is now used to configure the layout.

* See https://github.com/yast/yast-yast2/pull/1080
* See https://github.com/yast/yast-installation-control/pull/99

## Testing

* Manually tested.
