### PR TITLE
add test field to language and keyboard module (bsc#1174856)

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 22 10:09:33 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add test field to language & keyboard module (bsc#1174856)
+- 4.3.5
+
+-------------------------------------------------------------------
 Mon Aug 10 17:15:51 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(firstboot) into the spec file

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.3.4
+Version:        4.3.5
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/clients/firstboot_language_keyboard.rb
+++ b/src/clients/firstboot_language_keyboard.rb
@@ -102,6 +102,12 @@ module Yast
               HSquash(Icon.Simple("yast-keyboard")),
               HSpacing(2),
               Left(@keyboardsel)
+            ),
+            VSpacing(1),
+            HBox(
+              HSquash(Icon.Simple("yast-keyboard")),
+              HSpacing(2),
+              Left(InputField(Opt(:hstretch), _("&Test")))
             )
           )
         ),


### PR DESCRIPTION
## Task

Apply https://github.com/yast/yast-firstboot/pull/105 to `master` branch.

## Original Task

- https://bugzilla.suse.com/show_bug.cgi?id=1174856
- https://trello.com/c/mVt37N0M

Add a 'Test' field to language & keyboard module.

## Screenshots

![foo1](https://user-images.githubusercontent.com/927244/93866461-f8bc4180-fcc7-11ea-9dff-f4a8587322fe.png)
![foo2](https://user-images.githubusercontent.com/927244/93866695-4d5fbc80-fcc8-11ea-9680-89e195b35200.png)