### PR TITLE
Network improvements (bsc#1177797)

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -115,6 +115,13 @@
                     <label>Network</label>
                     <name>inst_lan</name>
                     <enabled config:type="boolean">false</enabled>
+                    <!-- By default the network configuration sequence is
+                         skipped if the network is already configured -->
+                    <!-- Uncomment to force the run of the network configuration sequence.
+                      <arguments>
+                        <skip_detection config:type="boolean">true</skip_detection>
+                      </arguments>
+                    -->
                 </module>
                  <module>
                     <label>Automatic Configuration</label>
@@ -135,11 +142,6 @@
                     <label>Desktop</label>
                     <enabled config:type="boolean">false</enabled>
                     <name>firstboot_desktop</name>
-                </module>
-                <module>
-                    <label>Network</label>
-                    <name>inst_lan</name>
-                    <enabled config:type="boolean">false</enabled>
                 </module>
                 <module>
                     <label>Users</label>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 16 09:18:59 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Removed duplicated lan client from the firstboot control file and
+  modified the firstboot_dhcp_setup client using the installation
+  dhcp setup client directly (bsc#1177797)
+- 4.3.8
+
+-------------------------------------------------------------------
 Mon Oct 19 12:51:29 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt to changes done in ntp-client (bsc#1177797)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/clients/firstboot_setup_dhcp.rb
+++ b/src/clients/firstboot_setup_dhcp.rb
@@ -1,6 +1,3 @@
-require "yast"
-require "network/network_autoconfiguration"
+require "network/clients/inst_setup_dhcp"
 
-Yast::NetworkAutoconfiguration.instance.configure_dhcp
-
-:next
+Yast::SetupDhcp.instance.main


### PR DESCRIPTION
## Problem

- It has been reported that the network configuration client is duplicated in the firstboot.xml module, and that there is some automatic configuration that is done during the firstboot which affects later the run of the network configuration sequence which is skipped.

- https://bugzilla.suse.com/show_bug.cgi?id=1177797

## Solution

- Removed the duplicate entry from the firstboot control file.
- Commented the option to force a run of the network configuration sequence in case that it was already configured.
- Do not perform a network autoconfiguration using dhcp if the network is not managed by wicked.