### PR TITLE
Fix: Starting YaST2 Control Center if the flag SHOW_Y2CC_CHECKBOX has…

### DIFF
--- a/control/firstboot.xml
+++ b/control/firstboot.xml
@@ -172,7 +172,7 @@
                 </module>
                 <module>
                     <label>Finish Setup</label>
-                    <name>inst_congratulate</name>
+                    <name>firstboot_finish</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Dec  4 16:12:43 UTC 2020 - Stefan Schubert <schubi@suse.de>
+
+- Fix: Starting YaST2 Control Center if the flag SHOW_Y2CC_CHECKBOX
+  has been set in /etc/sysconfig/firstboot and the user has
+  selected it while the firstboot installation workflow
+  (bsc#1178834).
+- 4.3.9
+
+-------------------------------------------------------------------
 Mon Nov 16 09:18:59 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Removed duplicated lan client from the firstboot control file and

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.3.8
+Version:        4.3.9
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/clients/firstboot_finish.rb
+++ b/src/clients/firstboot_finish.rb
@@ -30,7 +30,6 @@
 module Yast
   class FirstbootFinishClient < Client
     def main
-      Yast.import "Pkg"
       Yast.import "UI"
       textdomain "firstboot"
 
@@ -42,13 +41,12 @@ module Yast
       Yast.import "Label"
       Yast.import "Firstboot"
       Yast.import "GetInstArgs"
+      Yast.import "Package"
 
       @display = UI.GetDisplayInfo
 
-      if !Ops.get_boolean(@display, "TextMode", true)
-        if !Pkg.IsProvided("yast2-control-center")
-          Firstboot.show_y2cc_checkbox = false
-        end
+      if !Package.Installed("yast2-control-center")
+        Firstboot.show_y2cc_checkbox = false
       end
 
       @space = Ops.get_boolean(@display, "TextMode", true) ? 1 : 3


### PR DESCRIPTION
… been set in /etc/sysconfig/firstboot and the user has selected it while the firstboot installation workflow (bsc#1178834).