### PR TITLE
Firstboot hostname hosts improvements

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Dec 14 12:54:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Map the current static hostname only to the primary IP address
+  of the connections without a hostname.
+- Do not write network changes that are not related with the
+  hostname client (bsc#1178834)
+- 4.3.10
+
+-------------------------------------------------------------------
 Fri Dec  4 16:12:43 UTC 2020 - Stefan Schubert <schubi@suse.de>
 
 - Fix: Starting YaST2 Control Center if the flag SHOW_Y2CC_CHECKBOX

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST
@@ -40,7 +40,7 @@ Requires:       yast2-country >= 4.3.10
 # Rely on the YaST2-Firstboot.service for halting the system on failure
 Requires:       yast2-installation >= 4.1.2
 # Use Yast::Lan.write_config to write hostname changes
-Requires:       yast2-network >= 4.3.13
+Requires:       yast2-network >= 4.3.34
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-configuration-management >= 4.1.3
 

--- a/src/lib/y2firstboot/clients/hostname.rb
+++ b/src/lib/y2firstboot/clients/hostname.rb
@@ -168,16 +168,9 @@ module Y2Firstboot
       # FIXME: is this correct at all? what if there are multiple static ips
       # without aliases.
       def hostname_to_static_ips
-        ips = static_ips.select { |ip| Yast::Host.names(ip).empty? }
-        ips.each { |i| Yast::Host.Update(DNS.hostname, DNS.hostname, i) }
-      end
-
-      # Convenience method to obtain all the configured static ips
-      #
-      # @return [Array<String>]
-      def static_ips
-        ips = yast_config&.connections&.map { |c| c.all_ips.map { |i| i.address&.address&.to_s } }
-        (ips || []).flatten.compact
+        (yast_config&.connections || []).select { |c| c.hostname.to_s.empty? }.map do |conn|
+          conn.hostname = DNS.hostname
+        end
       end
 
       # Convenience method to obtain the current network configuration
@@ -189,7 +182,7 @@ module Y2Firstboot
 
       # Convenience method to write the config changes
       def write_config
-        Yast::Lan.write_config
+        Yast::Lan.write_config(only: [:dns, :hostname, :connections])
       end
     end
   end


### PR DESCRIPTION
## Problem

Currently, we are proposing the map of the hostname to all the IP addresses without it and we are also writing the whole network configuration

- https://trello.com/c/G1OvvwjV/2104-3-sle15-sp2-1174431-yast-network-yast-does-not-update-ip-aliases-when-the-hostname-is-modified

## Solution

- Map the current static hostname only to the primary IP address  of the connections without a hostname.
- Do not write network changes that are not related with the hostname client
