### PR TITLE
Drop cc option

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 30 12:19:47 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Drop starting YaST2 Control Center after first boot as it has
+  even more issues and running it after boot finish is works
+  (bsc#1180266)
+- 4.3.11
+
+-------------------------------------------------------------------
 Mon Dec 14 12:54:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Map the current static hostname only to the primary IP address

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Mar 30 12:19:47 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
-- Drop starting YaST2 Control Center after first boot as it has
-  even more issues and running it after boot finish is works
+- Revent adding starting YaST2 Control Center after first boot as
+  it does not have production quality and just confuse users
   (bsc#1180266)
 - 4.3.11
 

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Mar 30 12:19:47 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
-- Revent adding starting YaST2 Control Center after first boot as
+- Revert adding starting YaST2 Control Center after first boot as
   it does not have production quality and just confuse users
   (bsc#1180266)
 - 4.3.11

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-firstboot
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 Group:          System/YaST

--- a/src/clients/firstboot_finish.rb
+++ b/src/clients/firstboot_finish.rb
@@ -45,24 +45,7 @@ module Yast
 
       @display = UI.GetDisplayInfo
 
-      if !Package.Installed("yast2-control-center")
-        Firstboot.show_y2cc_checkbox = false
-      end
-
       @space = Ops.get_boolean(@display, "TextMode", true) ? 1 : 3
-
-      # Check box: Should the YaST2 control center automatically
-      # be started after this part of the installation is done?
-      # Translators: About 40 characters max,
-      # use newlines for longer translations.
-      @check_box_start_y2cc = Empty()
-      if Firstboot.show_y2cc_checkbox
-        @check_box_start_y2cc = CheckBox(
-          Id(:start_y2cc),
-          _("&Start YaST Control Center"),
-          false
-        )
-      end
 
       # caption for dialog "Congratulation Dialog"
       @caption = _("Configuration Completed")
@@ -101,36 +84,21 @@ module Yast
           RichText(@finish_text),
           HSpacing(Ops.multiply(2, @space))
         ),
-        VSpacing(@space),
-        @check_box_start_y2cc,
         VSpacing(2)
       )
 
-      # help 1/4 for dialog "Congratulation Dialog"
+      # help 1/3 for dialog "Congratulation Dialog"
       @help = _("<p>Your system is ready for use.</p>") +
-        # help 2/4 for dialog "Congratulation Dialog"
+        # help 2/3 for dialog "Congratulation Dialog"
         _(
           "<p><b>Finish</b> will close the YaST installation and continue\nto the login screen.</p>\n"
         ) +
-        # help 3/4 for dialog "Congratulation Dialog"
+        # help 3/3 for dialog "Congratulation Dialog"
         _(
           "<p>If you choose the default graphical desktop KDE, you can\n" +
             "adjust some KDE settings to your hardware. Also notice\n" +
             "our SUSE Welcome Dialog.</p>\n"
         )
-
-      if Firstboot.show_y2cc_checkbox
-        # help 4/4 for dialog "Congratulation Dialog"
-        @help = Ops.add(
-          @help,
-          _(
-            "<p>If desired, experts can use the full range of SUSE's configuration\n" +
-              "modules at this time. Check <b>Start YaST Control Center</b> and it will start\n" +
-              "after <b>Finish</b>. Note: The Control Center does not have a back button to\n" +
-              "return to this installation sequence.</p>\n"
-          )
-        )
-      end
 
       Wizard.SetContents(
         @caption,
@@ -157,13 +125,6 @@ module Yast
       end until @ret == :next || @ret == :back
 
       Wizard.RestoreNextButton
-
-      if @ret == :next &&
-          Convert.to_boolean(UI.QueryWidget(Id(:start_y2cc), :Value))
-        # Create empty /var/lib/YaST2/start_y2cc file to signal the calling script
-        # that the YaST2 control center should be started after the installation
-        SCR.Write(path(".target.string"), "/var/lib/YaST2/start_y2cc", "")
-      end
 
       deep_copy(@ret)
     end

--- a/src/fillup/sysconfig.firstboot
+++ b/src/fillup/sysconfig.firstboot
@@ -51,12 +51,6 @@ FIRSTBOOT_NOVELL_LICENSE_DIR=""
 # (but preffered way is to define the text in the control file)
 FIRSTBOOT_FINISH_FILE=""
 
-## Type:        yesno
-## Default:     "no"
-#
-# Show YaST Control Center Checkbox in finish dialog
-SHOW_Y2CC_CHECKBOX="no"
-
 ## Type:        string(halt,continue,abort)
 ## Default:     "halt"
 #

--- a/src/modules/Firstboot.rb
+++ b/src/modules/Firstboot.rb
@@ -50,8 +50,6 @@ module Yast
 
       @no_text = _("No Text Available")
 
-      @show_y2cc_checkbox = false
-
       @language_changed = false
 
       # definition of firstboot sequence (and the default path)
@@ -80,10 +78,6 @@ module Yast
         )
         return
       end
-      @show_y2cc_checkbox = Misc.SysconfigRead(
-        path(".sysconfig.firstboot.SHOW_Y2CC_CHECKBOX"),
-        "no"
-      ) == "yes"
       @default_wm = Misc.SysconfigRead(
         path(".sysconfig.windowmanager.DEFAULT_WM"),
         "kde"
@@ -191,7 +185,6 @@ module Yast
       nil
     end
 
-    publish :variable => :show_y2cc_checkbox, :type => "boolean"
     publish :variable => :language_changed, :type => "boolean"
     publish :variable => :firstboot_control_file, :type => "string"
     publish :variable => :reconfig_file, :type => "string"


### PR DESCRIPTION
trello: https://trello.com/c/ygot2NxB/2240-sles15-sp3-p5-1180266-cant-exit-control-center-if-started-by-firstboot

Basically option to run control center in firstboot has more issues and is not in production quality. So we decided to drop it.