### PR TITLE
Adapt root and user clients to Y2User

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 17 07:43:12 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Adapt code to Y2Users (part of jsc#PM-2620).
+- 4.4.2
+
+-------------------------------------------------------------------
 Sun May 16 08:11:46 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - only list specific files installed in common directories (metainfo,

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2firstboot/clients/root.rb
+++ b/src/lib/y2firstboot/clients/root.rb
@@ -30,7 +30,7 @@ module Y2Firstboot
   module Clients
     # Client for setting the root password
     class Root < Y2Users::Clients::InstRootFirst
-      # Overload {Y2Users::Clients::InstRootFirst#run} to wipe the encrypted password
+      # Overload Y2Users::Clients::InstRootFirst#run to wipe the encrypted password
       # @see #reset_password
       def run
         reset_password

--- a/src/lib/y2firstboot/clients/root.rb
+++ b/src/lib/y2firstboot/clients/root.rb
@@ -45,8 +45,8 @@ module Y2Firstboot
       # @note This method can be considered a sort of workaround for supporting
       # as much as possible a "clean" navigation through the Firstboot dialogs
       # when going back and forward (just in case the admin decides to offer
-      # such feature), EVEN THOUGH is not the intended behavior since Firstboot
-      # clients perform changes in the running system right away.
+      # such a feature), EVEN THOUGH is not the intended behavior since
+      # Firstboot clients perform changes in the running system right away.
       def reset_password
         return unless root_user.password&.value&.encrypted?
 

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -61,8 +61,8 @@ module Y2Firstboot
       # @note This method can be considered a sort of workaround for supporting
       # as much as possible a "clean" navigation through the Firstboot dialogs
       # when going back and forward (just in case the admin decides to offer
-      # such feature), EVEN THOUGH is not the intended behavior since Firstboot
-      # clients perform changes in the running system right away.
+      # such a feature), EVEN THOUGH is not the intended behavior since
+      # Firstboot clients perform changes in the running system right away.
       def reset_password
         return unless user.password&.value&.encrypted?
 
@@ -88,7 +88,7 @@ module Y2Firstboot
 
       # The user to be created/edited
       #
-      # @return [Y2Users::Userr]
+      # @return [Y2Users::User]
       def user
         @user ||= config.users.by_name(self.class.username) if self.class.username
         @user ||= Y2Users::User.new("")

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -21,34 +21,63 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2users/linux/writer"
+require "y2users/config_manager"
 require "users/dialogs/inst_user_first"
+
 Yast.import "Users"
-Yast.import "UsersSimple"
 Yast.import "Progress"
 
 module Y2Firstboot
   module Clients
-    # Client to set up the first user
+    # Client to set up the first user during the firstboot mode
     class User < Yast::Client
-      def initialize
-        Yast.include self, "users/routines.rb"
+      class << self
+        # @return [String, nil] the username of the created/edited user as a
+        # result of the execution of this client, if any. Needed for retrieving
+        # the user when going back and forward. See {#user}
+        attr_accessor :username
       end
 
       def run
-        dialog = Yast::InstUserFirstDialog.new
-        dialog_result = dialog.run
-        if dialog_result == :next && dialog.action == :new_user
-          # Change root password if needed
-          Yast::UsersSimple.Write
-          # Create user
-          if setup_all_users
-            # Do not mess with the progress indicator
-            orig = Yast::Progress.set(false)
-            Yast::Users.Write
-            Yast::Progress.set(orig)
-          end
+        result = Yast::InstUserFirstDialog.new(config, user: user).run
+
+        if result == :next
+          # Keeps the user name for future reference. See {#user}
+          self.class.username = user.attached? ? user.name : nil
+          write_config
         end
-        dialog_result
+
+        result
+      end
+
+    private
+
+      # Updates target configuration and writes it to the system
+      def write_config
+        Y2Users::ConfigManager.instance.target = config
+
+        writer = Y2Users::Linux::Writer.new(
+          Y2Users::ConfigManager.instance.target,
+          Y2Users::ConfigManager.instance.system(force_read: true)
+        )
+
+        writer.write
+      end
+
+      # A copy of config holding all the users on the system
+      #
+      # @return [Y2Users::Config]
+      def config
+        @config ||= Y2Users::ConfigManager.instance.system(force_read: true).copy
+      end
+
+      # The user to be created/edited
+      #
+      # @return [Y2Users::Userr]
+      def user
+        @user ||= config.users.by_name(self.class.username) if self.class.username
+        @user ||= Y2Users::User.new("")
       end
     end
   end

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -45,11 +45,10 @@ module Y2Firstboot
 
         result = Yast::InstUserFirstDialog.new(config, user: user).run
 
-        if result == :next
-          # Keeps the user name for future reference. See {#user}
-          self.class.username = user.attached? ? user.name : nil
-          write_config
-        end
+        write_config if result == :next
+
+        # Updates the username reference. See {#user}
+        self.class.username = user.attached? ? user.name : nil
 
         result
       end

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -69,9 +69,11 @@ module Y2Firstboot
         user.password = Y2Users::Password.create_plain("")
       end
 
+      # Writes config to the system
+      def write_config
         writer = Y2Users::Linux::Writer.new(
-          Y2Users::ConfigManager.instance.target,
-          Y2Users::ConfigManager.instance.system(force_read: true)
+          config,
+          Y2Users::ConfigManager.instance.system
         )
 
         writer.write

--- a/test/y2firstboot/clients/root_test.rb
+++ b/test/y2firstboot/clients/root_test.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firstboot/clients/root"
+
+describe Y2Firstboot::Clients::Root do
+  subject(:client) { described_class.new }
+
+  describe "#run" do
+    let(:inst_root_dialog) { instance_double(Yast::InstRootFirstDialog, run: result) }
+    let(:writer) { instance_double(Y2Users::Linux::Writer, write: []) }
+
+    let(:target_config)      { Y2Users::Config.new }
+    let(:system_config)      { Y2Users::Config.new }
+    let(:system_config_copy) { Y2Users::Config.new }
+    let(:config_manager)     { Y2Users::ConfigManager.instance }
+
+    before do
+      allow(Yast::InstRootFirstDialog).to receive(:new).and_return(inst_root_dialog)
+
+      allow(Y2Users::Linux::Writer).to receive(:new).and_return(writer)
+
+      allow(system_config).to receive(:copy).and_return(system_config_copy)
+      allow(config_manager).to receive(:target).and_return(target_config)
+      allow(config_manager).to receive(:system).and_return(system_config)
+    end
+
+    context "when inst_root_dialog result is :next" do
+      let(:result) { :next }
+
+      it "updates users target configuration" do
+        expect(config_manager).to receive(:target=).with(system_config_copy)
+
+        subject.run
+      end
+
+      it "writes the target users configuration" do
+        expect(Y2Users::Linux::Writer).to receive(:new).with(target_config, system_config)
+        expect(writer).to receive(:write)
+
+        subject.run
+      end
+    end
+
+    context "when inst_root_dialog result is not :next" do
+      let(:result) { :back }
+
+      it "does not update users target configuration" do
+        expect(config_manager).to_not receive(:target=)
+
+        subject.run
+      end
+
+      it "does not write users configuration" do
+        expect(Y2Users::Linux::Writer).to_not receive(:new)
+        expect(writer).to_not receive(:write)
+
+        subject.run
+      end
+    end
+  end
+end

--- a/test/y2firstboot/clients/user_test.rb
+++ b/test/y2firstboot/clients/user_test.rb
@@ -97,40 +97,34 @@ describe Y2Firstboot::Clients::User do
 
         subject.run
       end
-
-      context "and user still attached to the config" do
-        let(:attached) { true }
-
-        it "saves the username for future reference" do
-          expect(described_class).to receive(:username=).with(username)
-
-          subject.run
-        end
-      end
-
-      context "but user is not attached to the config" do
-        let(:attached) { false }
-
-        it "deletes username reference" do
-          expect(described_class).to receive(:username=).with(nil)
-
-          subject.run
-        end
-      end
     end
 
     context "when dialog result is not :next" do
       let(:result) { :back }
 
-      it "does not modify stored username" do
-        expect(described_class).to_not receive(:username=)
-
-        subject.run
-      end
-
       it "does not write the users configuration" do
         expect(Y2Users::Linux::Writer).to_not receive(:new)
         expect(writer).to_not receive(:write)
+
+        subject.run
+      end
+    end
+
+    context "if user is attached" do
+      let(:attached) { true }
+
+      it "saves the username for future reference" do
+        expect(described_class).to receive(:username=).with(username)
+
+        subject.run
+      end
+    end
+
+    context "if user is not attached" do
+      let(:attached) { false }
+
+      it "deletes username reference" do
+        expect(described_class).to receive(:username=).with(nil)
 
         subject.run
       end

--- a/test/y2firstboot/clients/user_test.rb
+++ b/test/y2firstboot/clients/user_test.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firstboot/clients/user"
+
+describe Y2Firstboot::Clients::User do
+  subject(:client) { described_class.new }
+
+  describe "#run" do
+    let(:dialog) { instance_double(Yast::InstUserFirstDialog, run: result) }
+    let(:result) { :next }
+
+    let(:user)     { Y2Users::User.new(username) }
+    let(:username) { "chamaleon" }
+    let(:attached) { false }
+
+    let(:system_config)      { Y2Users::Config.new }
+    let(:system_config_copy) { Y2Users::Config.new }
+    let(:config_manager)     { Y2Users::ConfigManager.instance }
+
+    let(:writer) { instance_double(Y2Users::Linux::Writer, write: []) }
+
+    before do
+      allow(Yast::InstUserFirstDialog).to receive(:new).and_return(dialog)
+
+      allow(Y2Users::Linux::Writer).to receive(:new).and_return(writer)
+
+      allow(subject).to receive(:user).and_return(user)
+      allow(user).to receive(:attached?).and_return(attached)
+
+      allow(system_config).to receive(:copy).and_return(system_config_copy)
+      allow(config_manager).to receive(:system).and_return(system_config)
+    end
+
+    it "executes the inst_user_first dialog" do
+      expect(Yast::InstUserFirstDialog).to receive(:new).with(system_config_copy, user: user)
+      expect(dialog).to receive(:run)
+
+      subject.run
+    end
+
+    it "returns the dialog result" do
+      expect(subject.run).to eq(result)
+    end
+
+    context "when dialog result is :next" do
+      it "updates the users target configuration" do
+        expect(config_manager).to receive(:target=).with(system_config_copy)
+
+        subject.run
+      end
+
+      it "writes the users configuration" do
+        expect(Y2Users::Linux::Writer).to receive(:new).with(system_config_copy, system_config)
+        expect(writer).to receive(:write)
+
+        subject.run
+      end
+
+      context "and user still attached to the config" do
+        let(:attached) { true }
+
+        it "saves the username for future reference" do
+          expect(described_class).to receive(:username=).with(username)
+
+          subject.run
+        end
+      end
+
+      context "but user is not attached to the config" do
+        let(:attached) { false }
+
+        it "deletes username reference" do
+          expect(described_class).to receive(:username=).with(nil)
+
+          subject.run
+        end
+      end
+    end
+
+    context "when dialog result is not :next" do
+      let(:result) { :back }
+
+      it "does not modify stored username" do
+        expect(described_class).to_not receive(:username=)
+
+        subject.run
+      end
+
+      it "does not write the users configuration" do
+        expect(Y2Users::Linux::Writer).to_not receive(:new)
+        expect(writer).to_not receive(:write)
+
+        subject.run
+      end
+    end
+  end
+end

--- a/test/y2firstboot/clients/user_test.rb
+++ b/test/y2firstboot/clients/user_test.rb
@@ -91,12 +91,6 @@ describe Y2Firstboot::Clients::User do
     end
 
     context "when dialog result is :next" do
-      it "updates the users target configuration" do
-        expect(config_manager).to receive(:target=).with(system_config_copy)
-
-        subject.run
-      end
-
       it "writes the users configuration" do
         expect(Y2Users::Linux::Writer).to receive(:new).with(system_config_copy, system_config)
         expect(writer).to receive(:write)


### PR DESCRIPTION
## Problem

*yast2-users* code is being adapted to use *shadow tools*. This module uses some API methods that are going to be dropped in favor of new `Y2Users` classes.

## Solution

Adapt code to use the new `Y2Users` classes.

NOTE: this PR should not be merged yet. It requires [*yast-users/y2users*](https://github.com/yast/yast-users/tree/y2users) branch to be merged before.

## Test

* Unit tests adapted
* Manually tested
 