### PR TITLE
Moved in ReallyAbortInst method from yast2-network

### DIFF
--- a/src/lib/y2firstboot/clients/hostname.rb
+++ b/src/lib/y2firstboot/clients/hostname.rb
@@ -88,7 +88,7 @@ module Y2Firstboot
 
     private
 
-      def ReallyAbortInst
+      def really_abort_inst
         Popup.ConfirmAbort(:incomplete)
       end
 
@@ -98,7 +98,7 @@ module Y2Firstboot
         functions = {
           "init"  => fun_ref(method(:InitHnWidget), "void (string)"),
           "store" => fun_ref(method(:StoreHnWidget), "void (string, map)"),
-          :abort  => fun_ref(method(:ReallyAbortInst), "boolean ()")
+          :abort  => fun_ref(method(:really_abort_inst), "boolean ()")
         }
         contents = HSquash(
           # Frame label

--- a/src/lib/y2firstboot/clients/hostname.rb
+++ b/src/lib/y2firstboot/clients/hostname.rb
@@ -88,6 +88,10 @@ module Y2Firstboot
 
     private
 
+      def ReallyAbortInst
+        Popup.ConfirmAbort(:incomplete)
+      end
+
       def hostname_dialog
         @hn_settings = InitSettings()
 


### PR DESCRIPTION
The method is going to be removed from yast2-network as it is no longer
used there.

http://github.com/yast/yast-network/pull/1221/