### PR TITLE
Sync home and username

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 10 16:29:28 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Move the home directory when the user login is modified in the
+  client for creating a user (related to bsc#1188612).
+- 4.4.4
+
+-------------------------------------------------------------------
 Fri Jul  9 11:59:31 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Remember plain passwords in order to provide a clean navigation

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -22,6 +22,7 @@ require "y2users/password"
 require "y2users/linux/writer"
 require "y2users/config_manager"
 require "users/dialogs/inst_user_first"
+require "pathname"
 
 module Y2Firstboot
   module Clients
@@ -62,6 +63,7 @@ module Y2Firstboot
         result = Yast::InstUserFirstDialog.new(config, user: user).run
 
         if result == :next
+          update_user
           write_config
           save_values
         end
@@ -70,6 +72,17 @@ module Y2Firstboot
       end
 
     private
+
+      # Updates user values, if needed
+      #
+      # For example, the home directory is modified to keep it on sync with the user name.
+      def update_user
+        home_path = Pathname.new(user.home || "")
+
+        return if user.home.nil? || user.name == home_path.basename.to_s
+
+        user.home = home_path.dirname.join(user.name).to_s
+      end
 
       # Writes config to the system
       def write_config

--- a/test/y2firstboot/clients/user_test.rb
+++ b/test/y2firstboot/clients/user_test.rb
@@ -118,6 +118,23 @@ describe Y2Firstboot::Clients::User do
         described_class.username = "test"
       end
 
+      context "if the user name does not match with the basename of the home directory" do
+        before do
+          user.home = "/home/test"
+        end
+
+        it "updates the home directory" do
+          expect(Yast::InstUserFirstDialog).to receive(:new) do |_, params|
+            user = params[:user]
+            user.name = "test2"
+          end.and_return(dialog)
+
+          subject.run
+
+          expect(user.home).to eq("/home/test2")
+        end
+      end
+
       it "writes the config to the system" do
         expect(Y2Users::Linux::Writer).to receive(:new)
           .with(config, system_config).and_call_original


### PR DESCRIPTION
### Problem

When going back in the wizard, the home directory/subvolume is not moved if the user's name is modified.

### Solution

Keep the user's name and home path in sync. The `Linux::Writer` class will take care of performing the required changes for moving the home directory/subvolume.

See https://github.com/yast/yast-users/pull/323

### Testing

* Added unit test.
* Manually tested.