### PR TITLE
Add WSL client

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jan 17 11:41:43 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Add client to configure settings for WSL images (jsc#SLE-20413).
+- Provide a yast2-firstboot-wsl subpackage to deploy specific
+  firstboot config for WSL.
+- 4.4.7
+
+-------------------------------------------------------------------
 Wed Sep 29 12:43:04 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Adap clients to changes in Y2Users API (related to jsc#SLE-20592)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -58,6 +58,14 @@ deployments where the system in the image is completely configured,
 however some last steps like root password and user logins have to be
 created to personalize the system.
 
+%package wsl
+Summary: YaST2 firstboot settings for WSL images
+
+Requires: %{name} = %{version}
+
+%description wsl
+YaST2 firstboot settings for WSL images
+
 %prep
 %setup -q
 
@@ -75,6 +83,11 @@ sed -i '/<name>registration/,+1s/false/true/' control/firstboot.xml
 %yast_metainfo
 
 mkdir -p %{buildroot}%{_datadir}/firstboot/scripts
+
+mkdir -p %{buildroot}/usr/share/YaST2/data
+
+install -m 644 wsl/firstboot.xml %{buildroot}/etc/YaST2/firstboot-wsl.xml
+install -m 644 wsl/welcome.txt %{buildroot}/usr/share/YaST2/data
 
 %check
 # verify defaults for registration
@@ -94,6 +107,12 @@ ruby -r rexml/document -e '
 %post
 %{fillup_only -n firstboot}
 
+%post wsl
+sed -i -E 's/(FIRSTBOOT_CONTROL_FILE=).+/\1"\/etc\/YaST2\/firstboot-wsl.xml"/' /etc/sysconfig/firstboot
+
+%postun wsl
+sed -i -E 's/(FIRSTBOOT_CONTROL_FILE=).+/\1""/' /etc/sysconfig/firstboot
+
 %files
 %license COPYING
 %doc %{yast_docdir}
@@ -109,5 +128,9 @@ ruby -r rexml/document -e '
 %{_datadir}/autoinstall
 %{_datadir}/icons/hicolor/*/apps/yast-firstboot*
 %{_sysconfdir}/YaST2
+
+%files wsl
+/etc/YaST2/firstboot-wsl.xml
+/usr/share/YaST2/data/welcome.txt
 
 %changelog

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,8 @@ client_DATA = \
   clients/firstboot_hostname.rb \
   clients/firstboot_root.rb \
   clients/firstboot_user.rb \
-  clients/firstboot_configuration_management.rb
+  clients/firstboot_configuration_management.rb \
+  clients/firstboot_wsl.rb
 
 yncludedir = @yncludedir@/firstboot
 ynclude_DATA = \
@@ -48,7 +49,8 @@ ylibclient_DATA = \
   lib/y2firstboot/clients/hostname.rb \
   lib/y2firstboot/clients/root.rb \
   lib/y2firstboot/clients/user.rb \
-  lib/y2firstboot/clients/licenses.rb
+  lib/y2firstboot/clients/licenses.rb \
+  lib/y2firstboot/clients/wsl.rb
 
 symbolicdir = @icondir@/hicolor/symbolic/apps
 symbolic_DATA = \

--- a/src/clients/firstboot_finish.rb
+++ b/src/clients/firstboot_finish.rb
@@ -42,6 +42,7 @@ module Yast
       Yast.import "Firstboot"
       Yast.import "GetInstArgs"
       Yast.import "Package"
+      Yast.import "ProductControl"
 
       @display = UI.GetDisplayInfo
 
@@ -50,8 +51,12 @@ module Yast
       # caption for dialog "Congratulation Dialog"
       @caption = _("Configuration Completed")
 
+      congratulate = ProductControl.GetTranslatedText("congratulate")
+
+      @text = congratulate unless congratulate.empty?
+
       # congratulation text 1/4
-      @text = _("<p><b>Congratulations!</b></p>") +
+      @text ||= _("<p><b>Congratulations!</b></p>") +
         # congratulation text 2/4
         _(
           "<p>The installation of &product; on your machine is complete.\nAfter clicking <b>Finish</b>, you can log in to the system.</p>\n"

--- a/src/clients/firstboot_wsl.rb
+++ b/src/clients/firstboot_wsl.rb
@@ -1,0 +1,24 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+
+require "yast"
+require "y2firstboot/clients/wsl"
+
+Y2Firstboot::Clients::WSL.new.run

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -1,0 +1,65 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/execute"
+require "y2firstboot/clients/user"
+require "etc"
+
+Yast.import "GetInstArgs"
+
+module Y2Firstboot
+  module Clients
+    # Client to set up required configuration for WSL
+    class WSL < Yast::Client
+      def run
+        return :back if Yast::GetInstArgs.going_back
+
+        write_wsl_user
+        setup_machine_id
+
+        :next
+      end
+
+    private
+
+      # Writes the id of the user created in firstboot (if any) in order to allow to WSL launcher to
+      # fetch it.
+      #
+      # WSL laucher fetches the user id from /run/wsl_firstboot_uid.
+      def write_wsl_user
+        user = Y2Firstboot::Clients::User.username
+
+        return unless user
+
+        uid = Etc.getpwnam(user).uid
+        File.write("/run/wsl_firstboot_uid", uid)
+      end
+
+      # Sets up the machine id, if needed
+      #
+      # The machine id is expected to be generated on first boot, but WSL does not really boot.
+      def setup_machine_id
+        # systemd-machine-id-setup is smart enough to only populate /etc/machine-id when empty or
+        # missing
+        Yast::Execute.locally("/usr/bin/systemd-machine-id-setup")
+      end
+    end
+  end
+end

--- a/test/y2firstboot/clients/wsl_test.rb
+++ b/test/y2firstboot/clients/wsl_test.rb
@@ -1,0 +1,94 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firstboot/clients/wsl"
+
+describe Y2Firstboot::Clients::WSL do
+  subject(:client) { described_class.new }
+
+  describe "#run" do
+    before do
+      allow(Yast::GetInstArgs).to receive(:going_back).and_return(going_back)
+
+      allow(Y2Firstboot::Clients::User).to receive(:username).and_return(username)
+
+      allow(Etc).to receive(:getpwnam).with(username).and_return(user)
+
+      allow(File).to receive(:write)
+
+      allow(Yast::Execute).to receive(:locally)
+    end
+
+    let(:going_back) { nil }
+
+    let(:username) { nil }
+
+    let(:user) { nil }
+
+    context "when going back from another client" do
+      let(:going_back) { true }
+
+      it "does nothing" do
+        expect(File).to_not receive(:write).with(/wsl_firstboot_uid/, anything)
+        expect(Yast::Execute).to_not receive(:locally).with(/systemd-machine-id-setup/)
+
+        subject.run
+      end
+
+      it "returns :back" do
+        expect(subject.run).to eq(:back)
+      end
+    end
+
+    context "when not going back from another client" do
+      let(:going_back) { false }
+
+      it "sets up the machine id" do
+        expect(Yast::Execute).to receive(:locally).with(/systemd-machine-id-setup/)
+
+        subject.run
+      end
+
+      context "when a user was created in firstboot" do
+        let(:username) { "test" }
+
+        let(:user) { Struct.new(:uid).new(1001) }
+
+        it "writes the user uid to /run/wsl_firstboot_uid" do
+          expect(File).to receive(:write).with("/run/wsl_firstboot_uid", 1001)
+
+          subject.run
+        end
+      end
+
+      context "when a user was not created in firstboot" do
+        let(:username) { nil }
+
+        it "does not write to /run/wsl_firstboot_uid" do
+          expect(File).to_not receive(:write).with("/run/wsl_firstboot_uid", anything)
+
+          subject.run
+        end
+      end
+    end
+  end
+end

--- a/wsl/firstboot.xml
+++ b/wsl/firstboot.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<productDefines  xmlns="http://www.suse.com/1.0/yast2ns"
+    xmlns:config="http://www.suse.com/1.0/configns">
+
+    <!--
+    $Id$
+    Work around for the text domain
+    textdomain="firstboot"
+    -->
+
+    <textdomain>firstboot</textdomain>
+
+	<!---
+	See https://github.com/yast/yast-installation/blob/master/doc/control-file.md for more
+	explanation about the control file settings.
+	-->
+
+    <globals>
+
+	<!--
+	If a variable root_password_as_first_user is present in globals section,
+	inst_user step will have the check box
+	    "Use this password for system administrator"
+	so you don't need to include root password step (fate#306297).
+	If the variable is missing (commented), the check box won't appear.
+
+	The value of the variable (true/false) will set the default value for the check box.
+	 -->
+	<root_password_as_first_user config:type="boolean">true</root_password_as_first_user>
+
+	<!-- The default value of "Automatic Login" checkbox -->
+	<enable_autologin config:type="boolean">false</enable_autologin>
+
+	<!-- This option is deprecated in favor of installation-layout -->
+	<!-- <installation_ui>sidebar</installation_ui> -->
+
+	<!-- Configuration of the installation/firstboot layout -->
+	<installation_layout>
+		<mode>steps</mode>
+		<banner config:type="boolean">false</banner>
+	</installation_layout>
+
+	<!--
+	For more variables that can be in this section, look into the control file
+	(/etc/YaST2/control.xml or root directory of installation media).
+	-->
+    </globals>
+    <proposals config:type="list">
+        <proposal>
+            <name>firstboot_hardware</name>
+            <mode>installation</mode>
+            <stage>firstboot</stage>
+            <label>Hardware Configuration</label>
+            <proposal_modules config:type="list">
+                <proposal_module>printer</proposal_module>
+            </proposal_modules>
+        </proposal>
+    </proposals>
+    <workflows  config:type="list">
+        <workflow>
+            <defaults>
+                <enable_back>yes</enable_back>
+                <enable_next>yes</enable_next>
+                <archs>all</archs>
+            </defaults>
+            <stage>firstboot</stage>
+            <label>Configuration</label>
+            <mode>installation</mode>
+            <modules  config:type="list">
+                <module>
+                    <label>Network Autosetup</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_setup_dhcp</name>
+                </module>
+                <module>
+                    <label>Language and Keyboard</label>
+                    <enabled config:type="boolean">false</enabled>
+		    <!-- step for configuration of both language and keyboard layout (fate#306296) -->
+                    <name>firstboot_language_keyboard</name>
+                </module>
+                <module>
+                    <label>Language</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_language</name>
+                </module>
+                <module>
+                    <label>Keyboard Layout</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_keyboard</name>
+                </module>
+                <module>
+                    <label>Welcome</label>
+                    <name>firstboot_welcome</name>
+                </module>
+                <module>
+                    <label>License Agreement</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_licenses</name>
+                </module>
+                <module>
+                    <label>Host Name</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_hostname</name>
+                </module>
+                <module>
+                    <label>Network</label>
+		    <!-- this step only restarts service 'network' -->
+                    <name>firstboot_network_write</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_ssh</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <name>inst_lan</name>
+                    <enabled config:type="boolean">false</enabled>
+                    <!-- By default the network configuration sequence is
+                         skipped if the network is already configured -->
+                    <!-- Uncomment to force the run of the network configuration sequence.
+                      <arguments>
+                        <skip_detection config:type="boolean">true</skip_detection>
+                      </arguments>
+                    -->
+                </module>
+                 <module>
+                    <label>Automatic Configuration</label>
+                    <name>inst_automatic_configuration</name>
+                    <enabled config:type="boolean">false</enabled>
+                 </module>
+                <module>
+                    <label>Time and Date</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_timezone</name>
+                </module>
+                <module>
+                    <label>NTP Client</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_ntp</name>
+                </module>
+                <module>
+                    <label>Desktop</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_desktop</name>
+                </module>
+                <module>
+                    <label>Users</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_user</name>
+                </module>
+                <module>
+                    <label>Root Password</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_root</name>
+                </module>
+                <module>
+                    <label>Customer Center</label>
+                    <name>registration</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <label>Hardware</label>
+                    <name>inst_proposal</name>
+                    <enabled config:type="boolean">false</enabled>
+                    <proposal>firstboot_hardware</proposal>
+                </module>
+                 <module>
+                    <label>Finish WSL Setup</label>
+                    <name>firstboot_wsl</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>no</enable_next>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>firstboot_write</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>no</enable_next>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>firstboot_finish</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+
+            </modules>
+        </workflow>
+    </workflows>
+    <texts>
+        <congratulate><label>
+            &lt;p&gt;Configuration of &amp;product; for WSL is complete!&lt;/p&gt;
+            &lt;p&gt;Call yast2 any time to tweak it.&lt;/p&gt;
+            &lt;p&gt;Have a lot of fun...&lt;/p&gt;
+        </label></congratulate>
+    </texts>
+</productDefines>

--- a/wsl/welcome.txt
+++ b/wsl/welcome.txt
@@ -1,0 +1,8 @@
+<p><b>Welcome to &product; on WSL!</b></p>
+<p>There are a few more steps to take before &product; is ready to
+use.</p>
+<p>It is recommended to create a Linux user account and set a
+password for the root account. The user name does not need to
+match the Windows user name. Please visit https://aka.ms/wslusers
+for more information.</p>
+<p>Hit <b>Next</b> to continue</p>


### PR DESCRIPTION
## Problem

Some settings need to be configured during the firstboot in order to properly work on WSL (Windows Subsystem for Linux). Threre already is a separate package *yast2-firstboot-wsl* which provides the clients and control file configuration for WSL firstboot. But that package only exists on OBS (no git repo). 

WSL firstboot config should be developed and maintained directly in *yast-firstboot* repository instead of having a kind of hacky separate OBS package.

* https://trello.com/c/AFsaWVkZ/2761-3-featurecould-have-move-wsl-specific-tasks-into-firstboot
* https://jira.suse.com/browse/SLE-20413
* https://build.opensuse.org/package/show/openSUSE:Factory/yast2-firstboot-wsl

## Solution

Provide WSL firstboot clients and configuration. A separate *yast2-firstboot-wsl* subpacakge is generated to deploy and prepare the configuration for WSL (firstboot-wsl.xml, custom messages, etc).

Note: the old *yast2-firstboot-wsl* must be removed from OBS. Deletion will be requested once this PR is accepted.

## Test

* Added unit tests
* Manually tested in Virtual Machine
* Manually tested on WSL (win10-2 machine from pong.suse.cz)