### PR TITLE
Update install to use sed logic result

### DIFF
--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -86,7 +86,7 @@ mkdir -p %{buildroot}%{_datadir}/firstboot/scripts
 
 mkdir -p %{buildroot}%{yast_ydatadir}
 
-install -m 644 wsl/firstboot.xml %{buildroot}%{_sysconfdir}/YaST2/firstboot-wsl.xml
+install -m 644 control/firstboot.xml %{buildroot}%{_sysconfdir}/YaST2/firstboot-wsl.xml
 install -m 644 wsl/welcome.txt %{buildroot}%{yast_ydatadir}
 
 %check


### PR DESCRIPTION
Line 78 sed makes proper change to 'control/firstboot.xml', but line 89 does an install for 'wsl/firstboot.xml' so the registration flag isn't properly changed for SLE.