### PR TITLE
WSL enable registration

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 21 15:44:30 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Registration step is always enabled for SLE, even when running
+  in WSL (bsc#1195776).
+- 4.4.8
+
+-------------------------------------------------------------------
 Mon Jan 17 11:41:43 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Add client to configure settings for WSL images (jsc#SLE-20413).

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -76,6 +76,7 @@ YaST2 firstboot settings for WSL images
 # lets explain this sed. At first it is address which match line with name
 # registration and +1 for next line and then here change false to true
 sed -i '/<name>registration/,+1s/false/true/' control/firstboot.xml
+sed -i '/<name>registration/,+1s/false/true/' wsl/firstboot.xml
 %endif
 
 %install

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only


### PR DESCRIPTION
### Problem

The registration step should be enabled by default in SLE, see [bsc#1162846](https://bugzilla.suse.com/show_bug.cgi?id=1162846). To accomplish this, the firstboot control file is modified when building the package (directly in the spec file).  The package *yast2-firstboow-wsl* was added as subpackage of *yast2-firstboot*, and each one has its own control file, see https://github.com/yast/yast-firstboot/pull/131. After these changes, the control file for *yast2-firstboot-wsl* was not enabling the registration step when needed.

* https://bugzilla.suse.com/show_bug.cgi?id=1195776

### Solution

Enable registration step in both, regular yast-firstboot control file and also for the WSL control file.

Note that having different control files makes fine tuning the steps for each case easier. In WSL there usually are some dedicated steps.

### Testing

* Manually tested
