### PR TITLE
Mark `wsl/firstboot.xml` file for translation (bsc#1197965)

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 11 14:44:06 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Extract the translatable texts also from the wsl/firstboot.xml
+  file (bsc#1197965)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (#bsc1198109)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/wsl/firstboot.glade
+++ b/wsl/firstboot.glade
@@ -1,0 +1,1 @@
+firstboot.xml


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1197965#c7
- The content of the `wsl/firstboot.xml` file was not marked for translation

## Solution

- Create a `wsl/firstboot.glade` ➞ `wsl/firstboot.xml` symlink
- See more details in https://bugzilla.suse.com/show_bug.cgi?id=1197965#c10

## Testing

- Tested manually

Without the symlink `rake pot` ignores the WSL file:
```console
# rake pot
/usr/bin/y2tool y2makepot
Processing ./control/firstboot.glade file...
Creating ./firstboot.pot from  ./control/firstboot.glade.translations.glade ...
...
```

With the symlink it is also included in the POT file:
```console
# rake pot
/usr/bin/y2tool y2makepot
Processing ./control/firstboot.glade file...
Processing ./wsl/firstboot.glade file...
Creating ./firstboot.pot from  ./control/firstboot.glade.translations.glade ./wsl/firstboot.glade.translations.glade ...
...
```
