### PR TITLE
Do not skip client for root password if missing user password

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 10 13:59:28 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Do not skip client for root password automatically if
+  the user password has not been set yet (bsc#1202228).
+- 4.4.9
+
+-------------------------------------------------------------------
 Mon Feb 21 15:44:30 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Registration step is always enabled for SLE, even when running

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2firstboot/clients/root.rb
+++ b/src/lib/y2firstboot/clients/root.rb
@@ -72,7 +72,9 @@ module Y2Firstboot
       def root_password_from_user?
         user_password = Y2Firstboot::Clients::User.user_password
 
-        user_password && user_password == Y2Firstboot::Clients::User.root_password
+        return false unless user_password
+
+        user_password == Y2Firstboot::Clients::User.root_password
       end
 
       # Writes the config to the system

--- a/src/lib/y2firstboot/clients/root.rb
+++ b/src/lib/y2firstboot/clients/root.rb
@@ -70,7 +70,9 @@ module Y2Firstboot
       #
       # @return [Boolean]
       def root_password_from_user?
-        Y2Firstboot::Clients::User.user_password == Y2Firstboot::Clients::User.root_password
+        user_password = Y2Firstboot::Clients::User.user_password
+
+        user_password && user_password == Y2Firstboot::Clients::User.root_password
       end
 
       # Writes the config to the system

--- a/test/y2firstboot/clients/root_test.rb
+++ b/test/y2firstboot/clients/root_test.rb
@@ -83,6 +83,19 @@ describe Y2Firstboot::Clients::Root do
         allow(Yast::GetInstArgs).to receive(:argmap).and_return("force" => false)
       end
 
+      context "and the first user password was not set either" do
+        before do
+          Y2Firstboot::Clients::User.user_password = nil
+          Y2Firstboot::Clients::User.root_password = nil
+        end
+
+        it "opens the dialog for configuring root" do
+          expect(dialog).to receive(:run)
+
+          subject.run
+        end
+      end
+
       context "and the user password was used for root" do
         before do
           Y2Firstboot::Clients::User.user_password = "S3cr3T"


### PR DESCRIPTION
## Problem

Back in #126, user clients were improved to work well when going back and forward. However, a check in the client for setting the root password is making to skip it automatically when none password has been set yet, the user nor the root password.

It makes it do not work as expected in a firstboot workflow with both clients active when the user decides to go for the _Skip User Creation_ option since at this point both passwords _might be_ `nil`.

- https://trello.com/c/6bjaZPhA
- https://bugzilla.suse.com/show_bug.cgi?id=1202228


## Solution

Avoid performing the [passwords comparison](https://github.com/yast/yast-firstboot/blob/41dc18af2da0a17517e09c6090d00290e19fc29c/src/lib/y2firstboot/clients/root.rb#L67-L74) when the user password is not set. 

## Testing

- Added a new unit test
- Tested manually: the client for setting the root password is not skipped when skipping the user creation


