### PR TITLE
[master] Do not skip client for root password if missing user password

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 10 13:59:28 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Do not skip client for root password automatically if
+  the user password has not been set yet (bsc#1202228).
+- 4.5.3
+
+-------------------------------------------------------------------
 Tue Apr 26 15:46:12 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed POT file comments (bsc#1198220)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2firstboot/clients/root.rb
+++ b/src/lib/y2firstboot/clients/root.rb
@@ -70,7 +70,11 @@ module Y2Firstboot
       #
       # @return [Boolean]
       def root_password_from_user?
-        Y2Firstboot::Clients::User.user_password == Y2Firstboot::Clients::User.root_password
+        user_password = Y2Firstboot::Clients::User.user_password
+
+        return false unless user_password
+
+        user_password == Y2Firstboot::Clients::User.root_password
       end
 
       # Writes the config to the system

--- a/test/y2firstboot/clients/root_test.rb
+++ b/test/y2firstboot/clients/root_test.rb
@@ -83,6 +83,19 @@ describe Y2Firstboot::Clients::Root do
         allow(Yast::GetInstArgs).to receive(:argmap).and_return("force" => false)
       end
 
+      context "and the first user password was not set either" do
+        before do
+          Y2Firstboot::Clients::User.user_password = nil
+          Y2Firstboot::Clients::User.root_password = nil
+        end
+
+        it "opens the dialog for configuring root" do
+          expect(dialog).to receive(:run)
+
+          subject.run
+        end
+      end
+
       context "and the user password was used for root" do
         before do
           Y2Firstboot::Clients::User.user_password = "S3cr3T"


### PR DESCRIPTION
Same as https://github.com/yast/yast-firstboot/pull/138 but for master

> Avoid performing the [passwords comparison](https://github.com/yast/yast-firstboot/blob/82f13cbf447df574ab5e771f063a5bce3a1320bf/src/lib/y2firstboot/clients/root.rb#L67-L74) when the user password is not set

- https://trello.com/c/6bjaZPhA
- https://bugzilla.suse.com/show_bug.cgi?id=1202228
