### PR TITLE
WSL product selection

### DIFF
--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 19 08:09:57 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Add client to select product in WSL (jsc#PED-1380).
+- Allow installing WSL GUI pattern (jsc#PM-3439).
+- 4.4.10
+
+-------------------------------------------------------------------
 Wed Aug 10 13:59:28 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Do not skip client for root password automatically if

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -77,6 +77,7 @@ YaST2 firstboot settings for WSL images
 # registration and +1 for next line and then here change false to true
 sed -i '/<name>registration/,+1s/false/true/' control/firstboot.xml
 sed -i '/<name>registration/,+1s/false/true/' wsl/firstboot.xml
+sed -i '/<name>firstboot_wsl_product_selection/,+1s/false/true/' wsl/firstboot.xml
 %endif
 
 %install

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.9
+Version:        4.4.10
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,8 @@ client_DATA = \
   clients/firstboot_root.rb \
   clients/firstboot_user.rb \
   clients/firstboot_configuration_management.rb \
-  clients/firstboot_wsl.rb
+  clients/firstboot_wsl.rb \
+  clients/firstboot_wsl_product_selection.rb
 
 yncludedir = @yncludedir@/firstboot
 ynclude_DATA = \
@@ -50,7 +51,14 @@ ylibclient_DATA = \
   lib/y2firstboot/clients/root.rb \
   lib/y2firstboot/clients/user.rb \
   lib/y2firstboot/clients/licenses.rb \
-  lib/y2firstboot/clients/wsl.rb
+  lib/y2firstboot/clients/wsl.rb \
+  lib/y2firstboot/clients/wsl_product_selection.rb
+
+ylib_DATA = \
+  lib/y2firstboot/wsl_config.rb
+
+ylibdialogs_DATA = \
+  lib/y2firstboot/dialogs/wsl_product_selection.rb
 
 symbolicdir = @icondir@/hicolor/symbolic/apps
 symbolic_DATA = \
@@ -59,6 +67,6 @@ scalabledir = @icondir@/hicolor/scalable/apps
 scalable_DATA = \
   icons/hicolor/scalable/apps/yast-firstboot.svg
 
-EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(fillup_DATA) $(ylibclient_DATA) $(symbolic_DATA) $(scalable_DATA)
+EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(fillup_DATA) $(ylibclient_DATA) ${ylib_DATA} ${ylibdialogs_DATA} $(symbolic_DATA) $(scalable_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,9 +54,11 @@ ylibclient_DATA = \
   lib/y2firstboot/clients/wsl.rb \
   lib/y2firstboot/clients/wsl_product_selection.rb
 
+ylibdir = "${yast2dir}/lib/y2firstboot"
 ylib_DATA = \
   lib/y2firstboot/wsl_config.rb
 
+ylibdialogsdir = "${yast2dir}/lib/y2firstboot/dialogs"
 ylibdialogs_DATA = \
   lib/y2firstboot/dialogs/wsl_product_selection.rb
 

--- a/src/clients/firstboot_wsl_product_selection.rb
+++ b/src/clients/firstboot_wsl_product_selection.rb
@@ -1,0 +1,22 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2firstboot/clients/wsl_product_selection"
+
+Y2Firstboot::Clients::WSLProductSelection.new.run

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -24,6 +24,7 @@ require "etc"
 require "y2firstboot/wsl_config"
 
 Yast.import "GetInstArgs"
+Yast.import "Report"
 
 module Y2Firstboot
   module Clients
@@ -80,7 +81,11 @@ module Y2Firstboot
       # (see client wsl_product_selection)
       def install_patterns
         Y2Firstboot::WSLConfig.instance.patterns.each do |pattern|
-          Yast::Pkg.ResolvableInstall(pattern, :pattern)
+          next if Yast::Pkg.ResolvableInstall(pattern, :pattern)
+
+          # TRANSLATORS: Error message, %s is a pattern name
+          Yast::Report.Error(_("Cannot select pattern\n\"%s\" to install.\n" \
+            "Some software might be missing.") % pattern)
         end
       end
     end

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -64,6 +64,8 @@ module Y2Firstboot
         Yast::Execute.locally("/usr/bin/systemd-machine-id-setup")
       end
 
+      # Performs changes in order to install the selected product
+      # (see client wsl_product_selection)
       def switch_product
         return unless Y2Firstboot::WSLConfig.instance.product_switched?
 
@@ -72,9 +74,10 @@ module Y2Firstboot
 
         Yast::Pkg.ResolvableRemove(installed_product, :product) if installed_product
         Yast::Pkg.ResolvableInstall(product, :product)
-        # TODO: check if pkg commit is done later or if it is needed here
       end
 
+      # Installs the selected patterns
+      # (see client wsl_product_selection)
       def install_patterns
         Y2Firstboot::WSLConfig.instance.patterns.each do |pattern|
           Yast::Pkg.ResolvableInstall(pattern, :pattern)

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -64,7 +64,7 @@ module Y2Firstboot
         Yast::Execute.locally("/usr/bin/systemd-machine-id-setup")
       end
 
-      # Performs changes in order to install the selected product
+      # Performs changes in order to remove the current product and install the selected product
       # (see client wsl_product_selection)
       def switch_product
         return unless Y2Firstboot::WSLConfig.instance.product_switched?
@@ -72,8 +72,8 @@ module Y2Firstboot
         product = Y2Firstboot::WSLConfig.instance.product
         installed_product = Y2Firstboot::WSLConfig.instance.installed_product
 
-        Yast::Pkg.ResolvableRemove(installed_product, :product) if installed_product
-        Yast::Pkg.ResolvableInstall(product, :product)
+        Yast::Pkg.ResolvableRemove(installed_product.name, :product) if installed_product
+        Yast::Pkg.ResolvableInstall(product["name"], :product)
       end
 
       # Installs the selected patterns

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -67,32 +67,14 @@ module Y2Firstboot
       end
 
       def switch_product
-        product = ensure_require("registration/storage") do
-          Registration::Storage::InstallationOptions.instance.product
-        end
+        return unless Y2Firstboot::WSLConfig.instance.product_switched?
 
-        return unless product
+        product = Y2Firstboot::WSLConfig.instance.product
+        installed_product = Y2Firstboot::WSLConfig.instance.installed_product
 
-        return if installed_product && installed_product.name == product
-
-        Yast::Pkg.ResolvableRemove(installed_product.name, :product) if installed_product
+        Yast::Pkg.ResolvableRemove(installed_product, :product) if installed_product
         Yast::Pkg.ResolvableInstall(product, :product)
         # TODO: check if pkg commit is done later or if it is needed here
-      end
-
-      def installed_product
-        @installed_product ||= ensure_require("registration/sw_mgmt") do
-          Registration::SwMgmt.base_installed_product
-        end
-      end
-
-      # Runs a block ensuring that the required files are correctly loaded
-      def ensure_require(files)
-        files.each { |f| require(f) }
-        yield
-      rescue LoadError => e
-        log.warn("Required files cannot be loaded: #{e.message}")
-        nil
       end
 
       def install_patterns

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -29,8 +29,6 @@ module Y2Firstboot
   module Clients
     # Client to set up required configuration for WSL
     class WSL < Yast::Client
-      include Yast::Logger
-
       def run
         return :back if Yast::GetInstArgs.going_back
 

--- a/src/lib/y2firstboot/clients/wsl.rb
+++ b/src/lib/y2firstboot/clients/wsl.rb
@@ -30,6 +30,11 @@ module Y2Firstboot
   module Clients
     # Client to set up required configuration for WSL
     class WSL < Yast::Client
+      def initialize
+        textdomain "firstboot"
+        super
+      end
+
       def run
         return :back if Yast::GetInstArgs.going_back
 

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2firstboot/dialogs/wsl_product_selection"
+require "registration/yaml_product"
 
 module Y2Firstboot
   module Clients
@@ -36,7 +37,7 @@ module Y2Firstboot
         result = dialog.run
 
         if result == :next
-          self.class.product = dialog.product
+          Registration::YamlProduct.select_product(dialog.product.id)
           self.class.wsl_gui_pattern = dialog.wsl_gui_pattern
         end
 
@@ -46,15 +47,15 @@ module Y2Firstboot
     private
 
       def default_product
-        products.find { |p| p.id == :sles }
+        Registration::YamlProduct.selected_product["name"]
       end
 
       # FIXME: read products from yaml file
       def products
-        [
-          FakeProduct.new(:sles, "SUSE Linux Entreprise Server SP4"),
-          FakeProduct.new(:sled, "SUSE Linux Entreprise Desktop SP4")
-        ]
+        products = Registration::YamlProduct.available_products
+        products.map do |p|
+          FakeProduct.new(p["name"], p["display_name"])
+        end
       end
 
       FakeProduct = Struct.new(:id, :label)

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -18,9 +18,10 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2firstboot/config"
+require "y2firstboot/wsl_config"
 require "y2firstboot/dialogs/wsl_product_selection"
 require "registration/yaml_products_reader"
+require "registration/storage"
 
 module Y2Firstboot
   module Clients
@@ -45,22 +46,22 @@ module Y2Firstboot
     private
 
       def product
-        Config.instance.product || default_product
+        Registration::Storage::InstallationOptions.instance.product || default_product
       end
 
       def product=(value)
-        Config.instance.product = value
+        Registration::Storage::InstallationOptions.instance.product = value
       end
 
       def wsl_gui_pattern?
-        Config.instance.patterns.include?("wsl_gui")
+        WSLConfig.instance.patterns.include?("wsl_gui")
       end
 
       def wsl_gui_pattern=(value)
         if value
-          Config.instance.patterns.push("wsl_gui").uniq!
+          WSLConfig.instance.patterns.push("wsl_gui").uniq!
         else
-          Config.instance.patterns.delete("wsl_gui")
+          WSLConfig.instance.patterns.delete("wsl_gui")
         end
       end
 

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -45,7 +45,7 @@ module Y2Firstboot
       def save(product:, wsl_gui_pattern:)
         self.product = product
         self.wsl_gui_pattern = wsl_gui_pattern
-        self.update_force_registration
+        self.update_registration
       end
 
       def product
@@ -68,10 +68,12 @@ module Y2Firstboot
         end
       end
 
-      def update_force_registration
-        force = WSLConfig.instance.product_switched? || wsl_gui_pattern?
+      def update_registration
+        force_registration = WSLConfig.instance.product_switched? || wsl_gui_pattern?
+        yaml_product = products.find { |p| p["name"] == WSLConfig.instance.product }
 
-        Registration::Storage::InstallationOptions.instance.force_registration = force
+        Registration::Storage::InstallationOptions.instance.force_registration = force_registration
+        Registration::Storage::InstallationOptions.instance.yaml_product = yaml_product
       end
 
       def default_product

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -48,9 +48,12 @@ module Y2Firstboot
 
     private
 
+      WSL_GUI_PATTERN = "wsl_gui".freeze
+      private_constant :WSL_GUI_PATTERN
+
       # Saves changes
       #
-      # @param product [String] Name of the selected product
+      # @param product [Hash] Selected product
       # @param wsl_gui_pattern [Boolean] Whether to install WSL GUI pattern
       def save(product:, wsl_gui_pattern:)
         self.product = product
@@ -58,11 +61,11 @@ module Y2Firstboot
         update_registration
       end
 
-      # Name of the product to use
+      # Product to use
       #
       # @see {ẂSLConfig}
       #
-      # @return [String]
+      # @return [Hash]
       def product
         WSLConfig.instance.product || default_product
       end
@@ -71,7 +74,7 @@ module Y2Firstboot
       #
       # @see {ẂSLConfig}
       #
-      # @param value [String] Name of the product
+      # @param value [Hash] A product
       def product=(value)
         WSLConfig.instance.product = value
       end
@@ -82,7 +85,7 @@ module Y2Firstboot
       #
       # @return [Boolean]
       def wsl_gui_pattern?
-        WSLConfig.instance.patterns.include?("wsl_gui")
+        WSLConfig.instance.patterns.include?(WSL_GUI_PATTERN)
       end
 
       # Sets whether to install the WSL GUI pattern
@@ -90,9 +93,9 @@ module Y2Firstboot
       # @param value [Boolean]
       def wsl_gui_pattern=(value)
         if value
-          WSLConfig.instance.patterns.push("wsl_gui").uniq!
+          WSLConfig.instance.patterns.push(WSL_GUI_PATTERN).uniq!
         else
-          WSLConfig.instance.patterns.delete("wsl_gui")
+          WSLConfig.instance.patterns.delete(WSL_GUI_PATTERN)
         end
       end
 
@@ -103,11 +106,11 @@ module Y2Firstboot
       #
       # @see {Registration::Storage::InstallationOptions}
       def update_registration
+        yaml_product = WSLConfig.instance.product
         force_registration = WSLConfig.instance.product_switched? || wsl_gui_pattern?
-        yaml_product = products.find { |p| p["name"] == WSLConfig.instance.product }
 
-        Registration::Storage::InstallationOptions.instance.force_registration = force_registration
         Registration::Storage::InstallationOptions.instance.yaml_product = yaml_product
+        Registration::Storage::InstallationOptions.instance.force_registration = force_registration
       end
 
       # Name of the default product to use from YAML file
@@ -116,8 +119,7 @@ module Y2Firstboot
       def default_product
         return nil if products.none?
 
-        default = products.find { |p| p["default"] } || products.first
-        default["name"]
+        products.find { |p| p["default"] } || products.first
       end
 
       # All products from YAML file

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -35,7 +35,7 @@ module Y2Firstboot
       def run
         require_registration
 
-        return :next if products.none?
+        return :auto if products.none?
 
         dialog = Dialogs::WSLProductSelection.new(products,
           default_product: product,

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -45,7 +45,7 @@ module Y2Firstboot
       def save(product:, wsl_gui_pattern:)
         self.product = product
         self.wsl_gui_pattern = wsl_gui_pattern
-        self.update_registration
+        update_registration
       end
 
       def product

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -35,22 +35,25 @@ module Y2Firstboot
 
         result = dialog.run
 
-        if result == :next
-          self.product = dialog.product
-          self.wsl_gui_pattern = dialog.wsl_gui_pattern
-        end
+        save(product: dialog.product, wsl_gui_pattern: dialog.wsl_gui_pattern) if result == :next
 
         result
       end
 
     private
 
+      def save(product:, wsl_gui_pattern:)
+        self.product = product
+        self.wsl_gui_pattern = wsl_gui_pattern
+        self.update_force_registration
+      end
+
       def product
-        Registration::Storage::InstallationOptions.instance.product || default_product
+        WSLConfig.instance.product || default_product
       end
 
       def product=(value)
-        Registration::Storage::InstallationOptions.instance.product = value
+        WSLConfig.instance.product = value
       end
 
       def wsl_gui_pattern?
@@ -63,6 +66,12 @@ module Y2Firstboot
         else
           WSLConfig.instance.patterns.delete("wsl_gui")
         end
+      end
+
+      def update_force_registration
+        force = WSLConfig.instance.product_switched? || wsl_gui_pattern?
+
+        Registration::Storage::InstallationOptions.instance.force_registration = force
       end
 
       def default_product

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -128,7 +128,7 @@ module Y2Firstboot
       #
       # @return [Array<Hash>]
       def products
-        @products ||= Registration::YamlProductsReader.new("/tmp/products.yml").read
+        @products ||= Registration::YamlProductsReader.new.read
       end
 
       # Tries to require yast2-registration files

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -29,7 +29,7 @@ module Y2Firstboot
     class WSLProductSelection < Yast::Client
       # Runs the client
       #
-      # @throw [RuntimeError] see {#require_registration}.
+      # @raise [RuntimeError] see {#require_registration}.
       #
       # @return [Symbol]
       def run
@@ -65,7 +65,7 @@ module Y2Firstboot
 
       # Product to use
       #
-      # @see {ẂSLConfig}
+      # @see ẂSLConfig
       #
       # @return [Hash]
       def product
@@ -74,7 +74,7 @@ module Y2Firstboot
 
       # Sets the product to use
       #
-      # @see {ẂSLConfig}
+      # @see ẂSLConfig
       #
       # @param value [Hash] A product
       def product=(value)
@@ -83,7 +83,7 @@ module Y2Firstboot
 
       # Whether the WSL GUI pattern should be installed
       #
-      # @see {ẂSLConfig}
+      # @see ẂSLConfig
       #
       # @return [Boolean]
       def wsl_gui_pattern?
@@ -106,7 +106,7 @@ module Y2Firstboot
       # Those values indicates to registration what product was selected and whether the product
       # has to be registered.
       #
-      # @see {Registration::Storage::InstallationOptions}
+      # @see Registration::Storage::InstallationOptions
       def update_registration
         yaml_product = WSLConfig.instance.product
         force_registration = WSLConfig.instance.product_switched? || wsl_gui_pattern?
@@ -135,7 +135,7 @@ module Y2Firstboot
       #
       # @note yast2-registration might not be available for some products (e.g., openSUSE).
       #
-      # @throw [RuntimeError] if yast2-registration files cannot be loaded
+      # @raise [RuntimeError] if yast2-registration files cannot be loaded
       def require_registration
         require "registration/yaml_products_reader"
         require "registration/storage"

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -1,0 +1,63 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2firstboot/dialogs/wsl_product_selection"
+
+module Y2Firstboot
+  module Clients
+    class WSLProductSelection < Yast::Client
+      class << self
+        attr_accessor :product
+
+        attr_accessor :wsl_gui_pattern
+      end
+
+      def run
+        return :next if products.none?
+
+        dialog = Dialogs::WSLProductSelection.new(products, default_product: default_product)
+        result = dialog.run
+
+        if result == :next
+          self.class.product = dialog.product
+          self.class.wsl_gui_pattern = dialog.wsl_gui_pattern
+        end
+
+        result
+      end
+
+    private
+
+      def default_product
+        products.find { |p| p.id == :sles }
+      end
+
+      # FIXME: read products from yaml file
+      def products
+        [
+          FakeProduct.new(:sles, "SUSE Linux Entreprise Server SP4"),
+          FakeProduct.new(:sled, "SUSE Linux Entreprise Desktop SP4")
+        ]
+      end
+
+      FakeProduct = Struct.new(:id, :label)
+    end
+  end
+end

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -24,13 +24,25 @@ Yast.import "UI"
 
 module Y2Firstboot
   module Dialogs
+    # Dialog for selecting the product to use with WSL
     class WSLProductSelection < ::UI::InstallationDialog
       include Yast::I18n
 
+      # Name of the selected product
+      #
+      # @return [String]
       attr_reader :product
 
+      # Whether the WSL GUI pattern was selected
+      #
+      # @return [Boolean]
       attr_reader :wsl_gui_pattern
 
+      # Constructor
+      #
+      # @param products [Array<Hash>] All possible products
+      # @param default_product [String] Name of the product selected by default
+      # @param wsl_gui_pattern [Boolean] Whether WSL GUI pattern is selected by default
       def initialize(products, default_product: nil, wsl_gui_pattern: false)
         textdomain "firstboot"
 
@@ -45,7 +57,7 @@ module Y2Firstboot
         super
       end
 
-      protected
+    protected
 
       def dialog_title
         _("Product Selection")
@@ -77,8 +89,11 @@ module Y2Firstboot
           "Registration is also required to install the WSL GUI pattern.")
       end
 
-      private
+    private
 
+      # All possible products to select
+      #
+      # @return [Array<Hash>]
       attr_reader :products
 
       def item_for(product)

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -31,12 +31,13 @@ module Y2Firstboot
 
       attr_reader :wsl_gui_pattern
 
-      def initialize(products, default_product: nil)
+      def initialize(products, default_product: nil, wsl_gui_pattern: false)
         textdomain "firstboot"
 
         super()
         @products = products
-        @default_product = default_product || products.first
+        @product = default_product || products.first&.fetch("name")
+        @wsl_gui_pattern = wsl_gui_pattern
       end
 
       def next_handler
@@ -63,7 +64,7 @@ module Y2Firstboot
               )
             ),
             VSpacing(2),
-            Left(CheckBox(Id(:wsl_gui_pattern), _("Install WSL GUI pattern"), false))
+            Left(CheckBox(Id(:wsl_gui_pattern), _("Install WSL GUI pattern"), wsl_gui_pattern))
           )
         )
       end
@@ -78,17 +79,19 @@ module Y2Firstboot
 
       attr_reader :products
 
-      attr_reader :default_product
-
       def item_for(product)
-        Left(RadioButton(Id(product.id), product.label, product.id == default_product.id))
+        Left(
+          RadioButton(
+            Id(product["name"]),
+            product["display_name"],
+            product["name"] == self.product
+          )
+        )
       end
 
       def save
         @wsl_gui_pattern = Yast::UI.QueryWidget(Id(:wsl_gui_pattern), :Value)
-
-        product_id = Yast::UI.QueryWidget(Id(:product_selector), :Value)
-        @product = products.find { |p| p.id == product_id }
+        @product = Yast::UI.QueryWidget(Id(:product_selector), :Value)
       end
     end
   end

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -84,7 +84,7 @@ module Y2Firstboot
       end
 
       def help_text
-        _("Select the product to use with Windows Subsystem for Linux (WSL). \n\n" \
+        _("Select the product to use with Windows Subsystem for Linux (WSL).\n\n" \
           "Registering the product might be required in order to configure the selected product. " \
           "Registration is also required to install the WSL GUI pattern.")
       end
@@ -120,8 +120,8 @@ module Y2Firstboot
       def save
         @wsl_gui_pattern = Yast::UI.QueryWidget(Id(:wsl_gui_pattern), :Value)
 
-        name, version = Yast::UI.QueryWidget(Id(:product_selector), :Value).split(":")
-        @product = products.find { |p| p["name"] == name && p["version"] == version }
+        selected_id = Yast::UI.QueryWidget(Id(:product_selector), :Value)
+        @product = products.find { |p| item_id(p) == selected_id }
       end
     end
   end

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -28,9 +28,9 @@ module Y2Firstboot
     class WSLProductSelection < ::UI::InstallationDialog
       include Yast::I18n
 
-      # Name of the selected product
+      # Selected product
       #
-      # @return [String]
+      # @return [Hash]
       attr_reader :product
 
       # Whether the WSL GUI pattern was selected
@@ -41,14 +41,14 @@ module Y2Firstboot
       # Constructor
       #
       # @param products [Array<Hash>] All possible products
-      # @param default_product [String] Name of the product selected by default
+      # @param default_product [Hash] Product selected by default
       # @param wsl_gui_pattern [Boolean] Whether WSL GUI pattern is selected by default
       def initialize(products, default_product: nil, wsl_gui_pattern: false)
         textdomain "firstboot"
 
         super()
         @products = products
-        @product = default_product || products.first&.fetch("name")
+        @product = default_product || products.first
         @wsl_gui_pattern = wsl_gui_pattern
       end
 
@@ -96,19 +96,32 @@ module Y2Firstboot
       # @return [Array<Hash>]
       attr_reader :products
 
+      # Radio button for selecting a product
+      #
+      # @param product [Hash]
       def item_for(product)
         Left(
           RadioButton(
-            Id(product["name"]),
+            Id(item_id(product)),
             product["display_name"],
-            product["name"] == self.product
+            item_id(product) == item_id(self.product)
           )
         )
       end
 
+      # Id for the radio button
+      #
+      # @param product [Hash]
+      # @return [String]
+      def item_id(product)
+        "#{product["name"]}:#{product["version"]}"
+      end
+
       def save
         @wsl_gui_pattern = Yast::UI.QueryWidget(Id(:wsl_gui_pattern), :Value)
-        @product = Yast::UI.QueryWidget(Id(:product_selector), :Value)
+
+        name, version = Yast::UI.QueryWidget(Id(:product_selector), :Value).split(":")
+        @product = products.find { |p| p["name"] == name && p["version"] == version }
       end
     end
   end

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -63,16 +63,18 @@ module Y2Firstboot
                 *items
               )
             ),
-            VSpacing(2),
+            VSpacing(1),
+            Label(_("The WSL GUI pattern provides some needed packages for\n" \
+              "a better experience with graphical applications on WSL.")),
             Left(CheckBox(Id(:wsl_gui_pattern), _("Install WSL GUI pattern"), wsl_gui_pattern))
           )
         )
       end
 
-      # TODO
       def help_text
-        _("The WSL GUI pattern installs some needed dependencies for " \
-          "a nice out-of-the-box experience with GUI applications on WSL.")
+        _("Select the product to use with Windows Subsystem for Linux (WSL). \n\n" \
+          "Registering the product might be required in order to configure the selected product. " \
+          "Registration is also required to install the WSL GUI pattern.")
       end
 
       private

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -1,0 +1,95 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "ui/installation_dialog"
+
+Yast.import "UI"
+
+module Y2Firstboot
+  module Dialogs
+    class WSLProductSelection < ::UI::InstallationDialog
+      include Yast::I18n
+
+      attr_reader :product
+
+      attr_reader :wsl_gui_pattern
+
+      def initialize(products, default_product: nil)
+        textdomain "firstboot"
+
+        super()
+        @products = products
+        @default_product = default_product || products.first
+      end
+
+      def next_handler
+        save
+        super
+      end
+
+      protected
+
+      def dialog_title
+        _("Product Selection")
+      end
+
+      def dialog_content
+        items = products.map { |p| item_for(p) }
+
+        HSquash(
+          VBox(
+            RadioButtonGroup(
+              Id(:product_selector),
+              VBox(
+                Left(Label(_("Select the product to use"))),
+                *items
+              )
+            ),
+            VSpacing(2),
+            Left(CheckBox(Id(:wsl_gui_pattern), _("Install WSL GUI pattern"), false))
+          )
+        )
+      end
+
+      # TODO
+      def help_text
+        _("The WSL GUI pattern installs some needed dependencies for " \
+          "a nice out-of-the-box experience with GUI applications on WSL.")
+      end
+
+      private
+
+      attr_reader :products
+
+      attr_reader :default_product
+
+      def item_for(product)
+        Left(RadioButton(Id(product.id), product.label, product.id == default_product.id))
+      end
+
+      def save
+        @wsl_gui_pattern = Yast::UI.QueryWidget(Id(:wsl_gui_pattern), :Value)
+
+        product_id = Yast::UI.QueryWidget(Id(:product_selector), :Value)
+        @product = products.find { |p| p.id == product_id }
+      end
+    end
+  end
+end

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "ui/installation_dialog"
+require "y2firstboot/wsl_config"
 
 Yast.import "UI"
 
@@ -60,6 +61,7 @@ module Y2Firstboot
     protected
 
       def dialog_title
+        # TRANSLATORS: dialog title
         _("Product Selection")
       end
 
@@ -71,22 +73,32 @@ module Y2Firstboot
             RadioButtonGroup(
               Id(:product_selector),
               VBox(
-                Left(Label(_("Select the product to use"))),
+                # TRANSLATORS: dialog heading
+                Left(Heading(_("Select the product to use"))),
+                VSpacing(1),
                 *items
               )
             ),
-            VSpacing(1),
+            VSpacing(2),
+            # TRANSLATORS:
             Label(_("The WSL GUI pattern provides some needed packages for\n" \
-              "a better experience with graphical applications on WSL.")),
-            Left(CheckBox(Id(:wsl_gui_pattern), _("Install WSL GUI pattern"), wsl_gui_pattern))
+              "a better experience with graphical applications in WSL.")),
+            VSpacing(1),
+            # TRANSLATORS: check box label
+            Left(CheckBox(Id(:wsl_gui_pattern),
+              _("Install WSL GUI pattern (requires registration)"),
+              wsl_gui_pattern))
           )
         )
       end
 
       def help_text
-        _("Select the product to use with Windows Subsystem for Linux (WSL).\n\n" \
-          "Registering the product might be required in order to configure the selected product. " \
-          "Registration is also required to install the WSL GUI pattern.")
+        # TRANSLATORS: help text (1/2)
+        _("<p>Select the product to use with Windows Subsystem for Linux (WSL). " \
+          "Some products might require registration.</p>") +
+          # TRANSLATORS: help text (2/2)
+          _("<p>To use graphical programs in WSL you need to install the WSL GUI pattern. " \
+              "In that case the system needs to be registered as well.</p>")
       end
 
     private
@@ -103,7 +115,7 @@ module Y2Firstboot
         Left(
           RadioButton(
             Id(item_id(product)),
-            product["display_name"],
+            product_label(product),
             item_id(product) == item_id(self.product)
           )
         )
@@ -115,6 +127,21 @@ module Y2Firstboot
       # @return [String]
       def item_id(product)
         "#{product["name"]}:#{product["version"]}"
+      end
+
+      def product_label(product)
+        label = product["display_name"]
+
+        installed_product = WSLConfig.instance.installed_product
+        if installed_product.name != product["name"] ||
+            installed_product.version_version != product["version"]
+
+          # TRANSLATORS: suffix displayed for the products which require registration,
+          # %s is a product name like "SUSE Linux Enterprise Server 15 SP4"
+          label = _("%s (requires registration)") % label
+        end
+
+        label
       end
 
       def save

--- a/src/lib/y2firstboot/wsl_config.rb
+++ b/src/lib/y2firstboot/wsl_config.rb
@@ -18,15 +18,43 @@
 # find current contact information at www.suse.com.
 
 require "singleton"
+require "y2packager/resolvable"
 
 module Y2Firstboot
   class WSLConfig
     include Singleton
 
+    attr_accessor :product
+
     attr_accessor :patterns
 
     def initialize
       @patterns = []
+    end
+
+    def product_switched?
+      return false unless installed_product && product
+
+      installed_product != product
+    end
+
+    def installed_product
+      @installed_product ||= find_installed_product&.name
+    end
+
+    private
+
+    def find_installed_product
+      init_package_system
+
+      Y2Packager::Resolvable.find(kind: :product, status: :installed, category: "base").first
+    end
+
+    def init_package_system
+      Yast.import "PackageSystem"
+
+      Yast::PackageSystem.EnsureTargetInit
+      Yast::PackageSystem.EnsureSourceInit
     end
   end
 end

--- a/src/lib/y2firstboot/wsl_config.rb
+++ b/src/lib/y2firstboot/wsl_config.rb
@@ -45,8 +45,10 @@ module Y2Firstboot
     def product_switched?
       return false unless installed_product && product
 
+      # "version_version" contains the version without the release number ("15.4"),
+      # unlike the "version" attribute ("15.4-0")
       installed_product.name != product["name"] ||
-        installed_product.version != product["version"]
+        installed_product.version_version != product["version"]
     end
 
     # Current installed product

--- a/src/lib/y2firstboot/wsl_config.rb
+++ b/src/lib/y2firstboot/wsl_config.rb
@@ -1,0 +1,32 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "singleton"
+
+module Y2Firstboot
+  class WSLConfig
+    include Singleton
+
+    attr_accessor :patterns
+
+    def initialize
+      @patterns = []
+    end
+  end
+end

--- a/src/lib/y2firstboot/wsl_config.rb
+++ b/src/lib/y2firstboot/wsl_config.rb
@@ -21,35 +21,51 @@ require "singleton"
 require "y2packager/resolvable"
 
 module Y2Firstboot
+  # Configuration for WSL firstboot
   class WSLConfig
     include Singleton
 
+    # Name of the product to use with WSL
+    #
+    # @return [String, nil]
     attr_accessor :product
 
+    # Patterns to install as part of the WSL configuration
+    #
+    # @return [Array<String>]
     attr_accessor :patterns
 
     def initialize
       @patterns = []
     end
 
+    # Whether the selected product is not the installed product
+    #
+    # @return [Boolean]
     def product_switched?
       return false unless installed_product && product
 
       installed_product != product
     end
 
+    # Current installed product
+    #
+    # @return [String, nil]
     def installed_product
       @installed_product ||= find_installed_product&.name
     end
 
-    private
+  private
 
+    # Finds the currently installed product
+    #
+    # @return [Y2Packager::Resolvable, nil]
     def find_installed_product
       init_package_system
-
       Y2Packager::Resolvable.find(kind: :product, status: :installed, category: "base").first
     end
 
+    # Initializes the package system
     def init_package_system
       Yast.import "PackageSystem"
 

--- a/src/lib/y2firstboot/wsl_config.rb
+++ b/src/lib/y2firstboot/wsl_config.rb
@@ -25,9 +25,9 @@ module Y2Firstboot
   class WSLConfig
     include Singleton
 
-    # Name of the product to use with WSL
+    # Product to use with WSL
     #
-    # @return [String, nil]
+    # @return [Hash, nil]
     attr_accessor :product
 
     # Patterns to install as part of the WSL configuration
@@ -45,14 +45,15 @@ module Y2Firstboot
     def product_switched?
       return false unless installed_product && product
 
-      installed_product != product
+      installed_product.name != product["name"] ||
+        installed_product.version != product["version"]
     end
 
     # Current installed product
     #
-    # @return [String, nil]
+    # @return [Y2Packager::Resolvable, nil]
     def installed_product
-      @installed_product ||= find_installed_product&.name
+      @installed_product ||= find_installed_product
     end
 
   private

--- a/test/y2firstboot/clients/wsl_product_selection_test.rb
+++ b/test/y2firstboot/clients/wsl_product_selection_test.rb
@@ -1,0 +1,252 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firstboot/clients/wsl_product_selection"
+require "y2firstboot/dialogs/wsl_product_selection"
+require "y2firstboot/wsl_config"
+require "singleton"
+
+describe Y2Firstboot::Clients::WSLProductSelection do
+  subject { described_class.new }
+
+  describe "#run" do
+    context "when yast2-registration is not available" do
+      before do
+        allow(subject).to receive(:require).with(/registration\/*/).and_raise(LoadError)
+      end
+
+      it "raises an exception" do
+        expect { subject.run }.to raise_error(RuntimeError, /yast2-registration/)
+      end
+    end
+
+    context "when yast2-registration is available" do
+      before do
+        allow(subject).to receive(:require_registration)
+      end
+
+      # Mimic yast-registration classes
+      module Registration
+        class YamlProductsReader
+          attr_reader :read
+        end
+
+        module Storage
+          class InstallationOptions
+            include Singleton
+
+            attr_accessor :yaml_product, :force_registration
+          end
+        end
+      end
+
+      context "and there are no products from YAML file" do
+        before do
+          allow_any_instance_of(Registration::YamlProductsReader).to receive(:read).and_return([])
+          allow(Y2Firstboot::Dialogs::WSLProductSelection).to receive(:new).and_return(dialog)
+        end
+
+        let(:dialog) { instance_double(Y2Firstboot::Dialogs::WSLProductSelection) }
+
+        it "does not run the dialog for selecting product" do
+          expect(dialog).to_not receive(:run)
+
+          subject.run
+        end
+
+        it "does not change the current WSL config" do
+          Y2Firstboot::WSLConfig.instance.product = { "name" => "test" }
+          Y2Firstboot::WSLConfig.instance.patterns = ["test"]
+
+          subject.run
+
+          expect(Y2Firstboot::WSLConfig.instance.product).to eq("name" => "test")
+          expect(Y2Firstboot::WSLConfig.instance.patterns).to contain_exactly("test")
+        end
+
+        it "returns :next" do
+          expect(subject.run).to eq(:next)
+        end
+      end
+
+      context "and there are products from YAML file" do
+        before do
+          allow_any_instance_of(Registration::YamlProductsReader)
+            .to receive(:read).and_return([sles, sled])
+
+          allow(Y2Firstboot::Dialogs::WSLProductSelection).to receive(:new).and_return(dialog)
+
+          allow(Y2Firstboot::WSLConfig.instance)
+            .to receive(:product_switched?).and_return(product_switched)
+        end
+
+        let(:sles) { { "name" => "SLES", "version" => "15.4" } }
+        let(:sled) { { "name" => "SLED", "version" => "15.4" } }
+
+        let(:dialog) do
+          instance_double(Y2Firstboot::Dialogs::WSLProductSelection,
+            run:             dialog_result,
+            product:         selected_product,
+            wsl_gui_pattern: wsl_gui_pattern)
+        end
+
+        let(:dialog_result) { :abort }
+        let(:selected_product) { nil }
+        let(:wsl_gui_pattern) { nil }
+
+        let(:product_switched) { false }
+
+        it "runs the dialog for selecting product" do
+          expect(dialog).to receive(:run)
+
+          subject.run
+        end
+
+        context "if the dialog is accepted" do
+          let(:dialog_result) { :next }
+          let(:selected_product) { sled }
+
+          it "stores the selected product in the WSL config" do
+            subject.run
+
+            expect(Y2Firstboot::WSLConfig.instance.product).to eq(sled)
+          end
+
+          context "if the WSL GUI pattern was selected" do
+            let(:wsl_gui_pattern) { true }
+
+            before do
+              Y2Firstboot::WSLConfig.instance.patterns = []
+            end
+
+            it "stores the WSL GUI pattern in the WSL config" do
+              subject.run
+
+              expect(Y2Firstboot::WSLConfig.instance.patterns).to include("wsl_gui")
+            end
+          end
+
+          context "if the WSL GUI pattern was not selected" do
+            let(:wsl_gui_pattern) { false }
+
+            before do
+              Y2Firstboot::WSLConfig.instance.patterns = ["wsl_gui"]
+            end
+
+            it "does not store the WSL GUI pattern in the WSL config" do
+              subject.run
+
+              expect(Y2Firstboot::WSLConfig.instance.patterns).to_not include("wsl_gui")
+            end
+          end
+
+          it "updates the product in registration storage" do
+            Registration::Storage::InstallationOptions.instance.yaml_product = nil
+
+            subject.run
+
+            expect(Registration::Storage::InstallationOptions.instance.yaml_product).to eq(sled)
+          end
+
+          context "if the product was switched" do
+            let(:product_switched) { true }
+            let(:wsl_gui_pattern) { false }
+
+            it "updates registration storage to force registration" do
+              Registration::Storage::InstallationOptions.instance.force_registration = false
+
+              subject.run
+
+              expect(Registration::Storage::InstallationOptions.instance.force_registration)
+                .to eq(true)
+            end
+          end
+
+          context "if the product was not switched" do
+            let(:product_switched) { false }
+
+            context "and the WSL GUI pattern was selected" do
+              let(:wsl_gui_pattern) { true }
+
+              it "updates registration storage to force registration" do
+                Registration::Storage::InstallationOptions.instance.force_registration = false
+
+                subject.run
+
+                expect(Registration::Storage::InstallationOptions.instance.force_registration)
+                  .to eq(true)
+              end
+            end
+
+            context "and the WSL GUI pattern was not selected" do
+              let(:wsl_gui_pattern) { false }
+
+              it "updates registration storage to not force registration" do
+                Registration::Storage::InstallationOptions.instance.force_registration = true
+
+                subject.run
+
+                expect(Registration::Storage::InstallationOptions.instance.force_registration)
+                  .to eq(false)
+              end
+            end
+          end
+
+          it "returns :next" do
+            expect(subject.run).to eq(:next)
+          end
+        end
+
+        context "if the dialog is not accepted" do
+          let(:dialog_result) { :cancel }
+          let(:selected_product) { sled }
+          let(:wsl_gui_pattern) { true }
+
+          it "does not change the WSL config" do
+            Y2Firstboot::WSLConfig.instance.product = sles
+            Y2Firstboot::WSLConfig.instance.patterns = []
+
+            subject.run
+
+            expect(Y2Firstboot::WSLConfig.instance.product).to eq(sles)
+            expect(Y2Firstboot::WSLConfig.instance.patterns).to eq([])
+          end
+
+          it "does not change the registration storage" do
+            Registration::Storage::InstallationOptions.instance.yaml_product = sles
+            Registration::Storage::InstallationOptions.instance.force_registration = false
+
+            subject.run
+
+            expect(Registration::Storage::InstallationOptions.instance.yaml_product).to eq(sles)
+            expect(Registration::Storage::InstallationOptions.instance.force_registration)
+              .to eq(false)
+          end
+
+          it "returns the dialog result" do
+            expect(subject.run).to eq(:cancel)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/y2firstboot/clients/wsl_product_selection_test.rb
+++ b/test/y2firstboot/clients/wsl_product_selection_test.rb
@@ -83,8 +83,8 @@ describe Y2Firstboot::Clients::WSLProductSelection do
           expect(Y2Firstboot::WSLConfig.instance.patterns).to contain_exactly("test")
         end
 
-        it "returns :next" do
-          expect(subject.run).to eq(:next)
+        it "returns :auto" do
+          expect(subject.run).to eq(:auto)
         end
       end
 

--- a/test/y2firstboot/clients/wsl_test.rb
+++ b/test/y2firstboot/clients/wsl_test.rb
@@ -105,8 +105,8 @@ describe Y2Firstboot::Clients::WSL do
       end
 
       context "when the product was switched" do
-        let(:installed_product) { "SLES" }
-        let(:product) { "SLED" }
+        let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version: "15.4") }
+        let(:product) { { "name" => "SLED", "version" => "15.4" } }
 
         it "removes the installed product" do
           expect(Yast::Pkg).to receive(:ResolvableRemove).with("SLES", :product)
@@ -122,8 +122,8 @@ describe Y2Firstboot::Clients::WSL do
       end
 
       context "when the product was not switched" do
-        let(:installed_product) { "SLES" }
-        let(:product) { "SLES" }
+        let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version: "15.4") }
+        let(:product) { { "name" => "SLES", "version" => "15.4" } }
 
         it "does remove the installed product" do
           expect(Yast::Pkg).to_not receive(:ResolvableRemove).with("SLES", :product)

--- a/test/y2firstboot/clients/wsl_test.rb
+++ b/test/y2firstboot/clients/wsl_test.rb
@@ -105,7 +105,13 @@ describe Y2Firstboot::Clients::WSL do
       end
 
       context "when the product was switched" do
-        let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version: "15.4") }
+        let(:installed_product) do
+          double(
+            Y2Packager::Resolvable,
+            name:            "SLES",
+            version_version: "15.4"
+          )
+        end
         let(:product) { { "name" => "SLED", "version" => "15.4" } }
 
         it "removes the installed product" do
@@ -122,7 +128,13 @@ describe Y2Firstboot::Clients::WSL do
       end
 
       context "when the product was not switched" do
-        let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version: "15.4") }
+        let(:installed_product) do
+          double(
+            Y2Packager::Resolvable,
+            name:            "SLES",
+            version_version: "15.4"
+          )
+        end
         let(:product) { { "name" => "SLES", "version" => "15.4" } }
 
         it "does remove the installed product" do

--- a/test/y2firstboot/clients/wsl_test.rb
+++ b/test/y2firstboot/clients/wsl_test.rb
@@ -157,7 +157,20 @@ describe Y2Firstboot::Clients::WSL do
 
         it "installs the selected patterns" do
           expect(Yast::Pkg).to receive(:ResolvableInstall).with("wsl_gui", :pattern)
+            .and_return(true)
           expect(Yast::Pkg).to receive(:ResolvableInstall).with("test", :pattern)
+            .and_return(true)
+
+          subject.run
+        end
+
+        it "reports an error when a pattern cannot be installed" do
+          expect(Yast::Pkg).to receive(:ResolvableInstall).with("wsl_gui", :pattern)
+            .and_return(false)
+          expect(Yast::Pkg).to receive(:ResolvableInstall).with("test", :pattern)
+            .and_return(true)
+
+          expect(Yast::Report).to receive(:Error).with(/wsl_gui/)
 
           subject.run
         end

--- a/test/y2firstboot/dialogs/wsl_product_selection_test.rb
+++ b/test/y2firstboot/dialogs/wsl_product_selection_test.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firstboot/dialogs/wsl_product_selection"
+
+Yast.import "UI"
+
+describe Y2Firstboot::Dialogs::WSLProductSelection do
+  include Yast::UIShortcuts
+
+  def find_widget(regexp, content)
+    regexp = regexp.to_s unless regexp.is_a?(Regexp)
+
+    content.nested_find do |element|
+      next unless element.is_a?(Yast::Term)
+
+      element.params.any? do |param|
+        param.is_a?(Yast::Term) &&
+          param.value == :id &&
+          regexp.match?(param.params.first.to_s)
+      end
+    end
+  end
+
+  subject do
+    described_class.new(products,
+      default_product: default_product, wsl_gui_pattern: wsl_gui_pattern)
+  end
+
+  let(:products) { [sles, sled] }
+  let(:sles) { { "name" => "SLES", "version" => "15.4" } }
+  let(:sled) { { "name" => "SLED", "version" => "15.4" } }
+
+  let(:default_product) { sled }
+  let(:wsl_gui_pattern) { false }
+
+  describe "#dialog_content" do
+    it "shows radio button box for selecting the product" do
+      widget = find_widget(:product_selector, subject.send(:dialog_content))
+
+      expect(widget).to_not be_nil
+    end
+
+    it "shows a radio button for each product" do
+      products.each do |product|
+        name = product["name"]
+        widget = find_widget(/#{name}/, subject.send(:dialog_content))
+        expect(widget).to_not be_nil
+      end
+    end
+
+    it "shows a check box for selecting the WSL GUI pattern" do
+      widget = find_widget(:wsl_gui_pattern, subject.send(:dialog_content))
+
+      expect(widget).to_not be_nil
+    end
+
+    it "automatically selects the default product" do
+      widget = find_widget(/SLED/, subject.send(:dialog_content))
+
+      expect(widget.params.last).to eq(true)
+    end
+
+    context "when WSL GUI pattern is indicated as selected" do
+      let(:wsl_gui_pattern) { true }
+
+      it "selects WSL GUI pattern checkbox by default" do
+        widget = find_widget(:wsl_gui_pattern, subject.send(:dialog_content))
+
+        expect(widget.params.last).to eq(true)
+      end
+    end
+
+    context "when WSL GUI pattern is not indicated as selected" do
+      let(:wsl_gui_pattern) { false }
+
+      it "does not select WSL GUI pattern checkbox by default" do
+        widget = find_widget(:wsl_gui_pattern, subject.send(:dialog_content))
+
+        expect(widget.params.last).to eq(false)
+      end
+    end
+  end
+
+  describe "#next_handler" do
+    before do
+      allow(Yast::UI).to receive(:QueryWidget).and_call_original
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:wsl_gui_pattern), :Value).and_return(true)
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:product_selector), :Value)
+        .and_return("SLES:15.4")
+    end
+
+    it "saves whether the WSL GUI pattern checkbox was selected" do
+      expect(subject.wsl_gui_pattern).to eq(false)
+
+      subject.next_handler
+
+      expect(subject.wsl_gui_pattern).to eq(true)
+    end
+
+    it "saves the selected product" do
+      expect(subject.product).to eq(sled)
+
+      subject.next_handler
+
+      expect(subject.product).to eq(sles)
+    end
+  end
+end

--- a/test/y2firstboot/dialogs/wsl_product_selection_test.rb
+++ b/test/y2firstboot/dialogs/wsl_product_selection_test.rb
@@ -53,6 +53,12 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
   let(:default_product) { sled }
   let(:wsl_gui_pattern) { false }
 
+  let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version_version: "15.4") }
+  before do
+    allow(Y2Firstboot::WSLConfig.instance).to receive(:installed_product)
+      .and_return(installed_product)
+  end
+
   describe "#dialog_content" do
     it "shows radio button box for selecting the product" do
       widget = find_widget(:product_selector, subject.send(:dialog_content))

--- a/test/y2firstboot/wsl_config_test.rb
+++ b/test/y2firstboot/wsl_config_test.rb
@@ -47,7 +47,13 @@ describe Y2Firstboot::WSLConfig do
     end
 
     context "when there is an installed product" do
-      let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version: "15.4") }
+      let(:installed_product) do
+        double(
+          Y2Packager::Resolvable,
+          name:            "SLES",
+          version_version: "15.4"
+        )
+      end
 
       context "and there is no selected product" do
         let(:product) { nil }

--- a/test/y2firstboot/wsl_config_test.rb
+++ b/test/y2firstboot/wsl_config_test.rb
@@ -47,7 +47,7 @@ describe Y2Firstboot::WSLConfig do
     end
 
     context "when there is an installed product" do
-      let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES") }
+      let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version: "15.4") }
 
       context "and there is no selected product" do
         let(:product) { nil }
@@ -58,15 +58,23 @@ describe Y2Firstboot::WSLConfig do
       end
 
       context "and the selected product is the installed product" do
-        let(:product) { "SLES" }
+        let(:product) { { "name" => "SLES", "version" => "15.4" } }
 
         it "returns false" do
           expect(subject.product_switched?).to eq(false)
         end
       end
 
+      context "and the selected product is the installed product with different version" do
+        let(:product) { { "name" => "SLES", "version" => "15.3" } }
+
+        it "returns true" do
+          expect(subject.product_switched?).to eq(true)
+        end
+      end
+
       context "and the selected product is not the installed product" do
-        let(:product) { "SLED" }
+        let(:product) { { "name" => "SLED", "version" => "15.4" } }
 
         it "returns true" do
           expect(subject.product_switched?).to eq(true)
@@ -89,8 +97,8 @@ describe Y2Firstboot::WSLConfig do
     context "when there is an installed product" do
       let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES") }
 
-      it "returns the name of the installed product" do
-        expect(subject.installed_product).to eq("SLES")
+      it "returns the installed product" do
+        expect(subject.installed_product.name).to eq("SLES")
       end
     end
 

--- a/test/y2firstboot/wsl_config_test.rb
+++ b/test/y2firstboot/wsl_config_test.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2firstboot/wsl_config"
+
+Yast.import "PackageSystem"
+
+describe Y2Firstboot::WSLConfig do
+  subject { described_class.instance }
+
+  before do
+    allow(Yast::PackageSystem).to receive(:EnsureTargetInit)
+    allow(Yast::PackageSystem).to receive(:EnsureSourceInit)
+
+    allow(Y2Packager::Resolvable)
+      .to receive(:find).with(a_hash_including(kind: :product)).and_return([installed_product])
+  end
+
+  after do
+    subject.instance_variable_set(:@installed_product, nil)
+  end
+
+  let(:installed_product) { nil }
+
+  describe "#product_switched?" do
+    before do
+      subject.product = product
+    end
+
+    context "when there is an installed product" do
+      let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES") }
+
+      context "and there is no selected product" do
+        let(:product) { nil }
+
+        it "returns false" do
+          expect(subject.product_switched?).to eq(false)
+        end
+      end
+
+      context "and the selected product is the installed product" do
+        let(:product) { "SLES" }
+
+        it "returns false" do
+          expect(subject.product_switched?).to eq(false)
+        end
+      end
+
+      context "and the selected product is not the installed product" do
+        let(:product) { "SLED" }
+
+        it "returns true" do
+          expect(subject.product_switched?).to eq(true)
+        end
+      end
+    end
+
+    context "when there is no installed product" do
+      let(:installed_product) { nil }
+
+      let(:product) { "SLES" }
+
+      it "returns false" do
+        expect(subject.product_switched?).to eq(false)
+      end
+    end
+  end
+
+  describe "#installed_product" do
+    context "when there is an installed product" do
+      let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES") }
+
+      it "returns the name of the installed product" do
+        expect(subject.installed_product).to eq("SLES")
+      end
+    end
+
+    context "when there is no installed product" do
+      let(:installed_product) { nil }
+
+      it "returns nil" do
+        expect(subject.installed_product).to be_nil
+      end
+    end
+  end
+end

--- a/wsl/firstboot.xml
+++ b/wsl/firstboot.xml
@@ -155,6 +155,11 @@
                     <name>firstboot_root</name>
                 </module>
                 <module>
+                    <label>Product Selection</label>
+                    <name>firstboot_wsl_product_selection</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
                     <label>Customer Center</label>
                     <name>registration</name>
                     <enabled config:type="boolean">false</enabled>

--- a/wsl/firstboot.xml
+++ b/wsl/firstboot.xml
@@ -177,7 +177,7 @@
                     <enable_next>no</enable_next>
                 </module>
                 <module>
-                    <label>Finish WSL Setup</label>
+                    <label>Package Installation</label>
                     <name>inst_rpmcopy</name>
                     <enable_back>no</enable_back>
                     <enable_next>no</enable_next>

--- a/wsl/firstboot.xml
+++ b/wsl/firstboot.xml
@@ -177,6 +177,12 @@
                     <enable_next>no</enable_next>
                 </module>
                 <module>
+                    <label>Finish WSL Setup</label>
+                    <name>inst_rpmcopy</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>no</enable_next>
+                </module>
+                <module>
                     <label>Finish Setup</label>
                     <name>firstboot_write</name>
                     <enable_back>no</enable_back>


### PR DESCRIPTION
## Problem

Now [WSLg](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps) allows executing GUI applications. The SUSE Enterprise Linux image shipped in MS Store is based on SLES, but SLED should be also offered as an option. And the idea is to not overbloat MS Store with too many images (we have already quite a lot there, and this would start doubling it).

* https://jira.suse.com/browse/PED-1380
* https://trello.com/c/4eHsDJqY/3136-featurewslsle15sp4-allow-admin-to-choose-whether-to-register-as-sles-or-sled.

## Solution

In order to avoid having different images in Windows Store for each SLE product (e.g., SLES, SLED, etc), the firstboot will provide a way to decide what product to use. The list of products to select is defined by a YAML file included in the WSL image (*/etc/YaST2/products.yaml*). A new wizard step for selecting the product is shown just before the registration step. This new client also allows to install the WSL GUI pattern for a better experience with graphical applications in WSL (https://jira.suse.com/browse/PM-3439).

Note: The WSL image is based on SLES, so selecting another product (e.g., SLED) will force the registration of the product. The registration will also be forced if the WSL GUI pattern is selected.  

This PR requires https://github.com/yast/yast-registration/pull/581.

## Testing

* Added unit tests
* Tested manually

## Screenshots

![wsl_selection](https://user-images.githubusercontent.com/907998/196693215-0ab65335-ffcb-4030-ab0c-df8fe0b4567d.png)

![wsl_selection_help](https://user-images.githubusercontent.com/907998/196693233-b87e459e-67a9-4aaf-83ee-1c8101aa02ad.png)
