### PR TITLE
Adapt the user client to the new Y2Users API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Dependencies
-      run: zypper --non-interactive install --no-recommends yast2-configuration-management
+      run: zypper --non-interactive install --no-recommends yast2-configuration-management yast2-users
 
     # just for easier debugging...
     - name: Inspect Installed Packages

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 27 08:28:30 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Adapt users client to the changes in yast2-users (related to
+  bsc#1206627).
+- 4.4.12
+
+-------------------------------------------------------------------
 Thu Oct 27 08:21:44 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Compute properly dependencies of WSL GUI pattern (jsc#PM-3439)

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -47,6 +47,9 @@ Recommends:     (icewm if libyui-qt)
 Supplements:    autoyast(firstboot)
 BuildArch:      noarch
 
+# New API for Y2Users::CommitConfig
+Conflicts:	yast2-users < 4.4.15
+
 %description
 The YaST firstboot utility runs after installation is completed.  It
 guides the user through a series of steps that allows for easier

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -21,7 +21,7 @@ require "yast"
 require "y2users/password"
 require "y2users/linux/writer"
 require "y2users/config_manager"
-require "y2users/commit_config_collection"
+require "y2users/user_commit_config"
 require "y2users/commit_config"
 require "users/dialogs/inst_user_first"
 require "pathname"
@@ -79,7 +79,7 @@ module Y2Firstboot
         writer = Y2Users::Linux::Writer.new(
           config,
           Y2Users::ConfigManager.instance.system,
-          commit_configs
+          commit_config
         )
 
         writer.write
@@ -147,11 +147,11 @@ module Y2Firstboot
         @root_user ||= config.users.root
       end
 
-      # Builds the commit configs to use when writing users
+      # Builds the commit config to use when writing users
       #
-      # @return [Y2Users::CommitConfigCollection]
-      def commit_configs
-        Y2Users::CommitConfigCollection.new.tap do |collection|
+      # @return [Y2Users::CommitConfig]
+      def commit_config
+        Y2Users::CommitConfig.new.tap do |commit_config|
           # Configure the actions to perform when committing a user.
           #
           #   - If the user is being created, its home should content the skel files
@@ -162,7 +162,7 @@ module Y2Firstboot
           #   should be set as owner of the existing directory (#adapt_home_ownership option).
           #   - When deleting the user (i.e., when going back to skip the user creation after
           #   creating it), its home must be removed too (#remove_home).
-          commit_config = Y2Users::CommitConfig.new.tap do |config|
+          user_config = Y2Users::UserCommitConfig.new.tap do |config|
             config.username = user.name
             config.home_without_skel = false
             config.move_home = true
@@ -173,7 +173,7 @@ module Y2Firstboot
             config.remove_home = true
           end
 
-          collection.add(commit_config)
+          commit_config.user_configs.add(user_config)
         end
       end
 

--- a/src/lib/y2firstboot/clients/user.rb
+++ b/src/lib/y2firstboot/clients/user.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2021] SUSE LLC
+# Copyright (c) [2016-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/test/y2firstboot/clients/user_test.rb
+++ b/test/y2firstboot/clients/user_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2018-2021] SUSE LLC
+# Copyright (c) [2018-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -125,15 +125,15 @@ describe Y2Firstboot::Clients::User do
       let(:writer) { instance_double(Y2Users::Linux::Writer) }
 
       it "writes the config to the system" do
-        expect(Y2Users::Linux::Writer).to receive(:new) do |target, system, commit_configs|
+        expect(Y2Users::Linux::Writer).to receive(:new) do |target, system, commit_config|
           expect(target).to eql(config)
           expect(system).to eql(system_config)
 
-          commit_config = commit_configs.by_username(user.name)
-          expect(commit_config.move_home?).to eq(true)
-          expect(commit_config.remove_home?).to eq(true)
-          expect(commit_config.adapt_home_ownership?).to eq(true)
-          expect(commit_config.home_without_skel?).to eq(false)
+          user_config = commit_config.user_configs.by_username(user.name)
+          expect(user_config.move_home?).to eq(true)
+          expect(user_config.remove_home?).to eq(true)
+          expect(user_config.adapt_home_ownership?).to eq(true)
+          expect(user_config.home_without_skel?).to eq(false)
         end.and_return(writer)
 
         expect(writer).to receive(:write)


### PR DESCRIPTION
## Problem

This previous pull request changed the API of `Y2Users`, breaking the user client: https://github.com/yast/yast-users/pull/374.

The breakage can be seen at these two tests and is easily reproducible manually:

* https://openqa.opensuse.org/tests/3455534#step/enable_autologin/3
* https://openqa.opensuse.org/tests/3455439#step/firstrun/5

## Solution

Adapt the *users* client of *yast2-firstboot* to the new `Y2Users` API.

## Testing

* Updated unit test.
* Tested manually at SLE-15-SP4. Seems to work as a charm.
