### PR TITLE
Wsl systemd

### DIFF
--- a/doc/testing_wsl.md
+++ b/doc/testing_wsl.md
@@ -1,0 +1,19 @@
+## Testing WSL Changes
+
+This document serve as reminder how is the optimal way to test changes done for WSL firstboot as working with
+windows server can be linux unfriendly and we would like to test without any mocking to get the best results.
+
+### Creating Testing APPX
+
+The easiest way for me is to use OBS. Find the target release for WSL image like `SUSE:SLE-15-SP6:Update:WSL`
+and branch there `kiwi-images-wsl` that is responsible for creation of appx. In your branch create package
+yast2-firstboot ( as it is usually inherited from target and does not live in WSL subproject ) and copy there
+modified sources with rake tarball. It is also mandatory to link or branch package `wsl-appx` as it ensures
+that certificate used for appx matches with the one used in kiwi.
+Another important think is to ensure that certificate for home repo is valid and not outdated. To check it use
+`osc signkey --sslcert home:...` and if it is invalid use `osc signkey --sslcert --create home:jreidinger`.
+
+### Installing Modified APPX
+
+Just follow instructions on https://en.opensuse.org/WSL/Manual_Installation
+If there are any issue appx installer gets quite useless error, so use help at https://en.opensuse.org/WSL/Debugging_Hints

--- a/doc/testing_wsl.md
+++ b/doc/testing_wsl.md
@@ -5,15 +5,15 @@ windows server can be linux unfriendly and we would like to test without any moc
 
 ### Creating Testing APPX
 
-The easiest way for me is to use OBS. Find the target release for WSL image like `SUSE:SLE-15-SP6:Update:WSL`
+The easiest way is to use OBS. Find the target release for WSL image like `SUSE:SLE-15-SP6:Update:WSL`
 and branch there `kiwi-images-wsl` that is responsible for creation of appx. In your branch create package
 yast2-firstboot ( as it is usually inherited from target and does not live in WSL subproject ) and copy there
 modified sources with rake tarball. It is also mandatory to link or branch package `wsl-appx` as it ensures
 that certificate used for appx matches with the one used in kiwi.
 Another important think is to ensure that certificate for home repo is valid and not outdated. To check it use
-`osc signkey --sslcert home:...` and if it is invalid use `osc signkey --sslcert --create home:jreidinger`.
+`osc signkey --sslcert home:...` and if it is invalid use `osc signkey --sslcert --create home:...`.
 
 ### Installing Modified APPX
 
-Just follow instructions on https://en.opensuse.org/WSL/Manual_Installation
-If there are any issue appx installer gets quite useless error, so use help at https://en.opensuse.org/WSL/Debugging_Hints
+Just follow instructions at https://en.opensuse.org/WSL/Manual_Installation
+Appx installer reports quite useless error when there is any issue, so use help at https://en.opensuse.org/WSL/Debugging_Hints

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 14 20:38:43 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Allow selection WSL systemd pattern (jsc#PED-5644, jsc#PED-5099)
+- 4.6.3
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-firstboot.changes
+++ b/package/yast2-firstboot.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Dec 14 20:38:43 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
-- Allow selection WSL systemd pattern (jsc#PED-5644, jsc#PED-5099)
+- Allow selecting WSL systemd pattern (jsc#PED-5644, jsc#PED-5099)
 - 4.6.3
 
 -------------------------------------------------------------------

--- a/package/yast2-firstboot.spec
+++ b/package/yast2-firstboot.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firstboot
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Initial System Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2firstboot/clients/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/clients/wsl_product_selection.rb
@@ -38,15 +38,15 @@ module Y2Firstboot
         return :auto if products.none?
 
         dialog = Dialogs::WSLProductSelection.new(products,
-          default_product: product,
-          wsl_gui_pattern: wsl_gui_pattern?,
+          default_product:     product,
+          wsl_gui_pattern:     wsl_gui_pattern?,
           wsl_systemd_pattern: wsl_systemd_pattern?)
 
         result = dialog.run
 
         if result == :next
-          save(product: dialog.product,
-               wsl_gui_pattern: dialog.wsl_gui_pattern,
+          save(product:             dialog.product,
+               wsl_gui_pattern:     dialog.wsl_gui_pattern,
                wsl_systemd_pattern: dialog.wsl_systemd_pattern)
         end
 
@@ -137,7 +137,8 @@ module Y2Firstboot
       # @see Registration::Storage::InstallationOptions
       def update_registration
         yaml_product = WSLConfig.instance.product
-        force_registration = WSLConfig.instance.product_switched? || wsl_gui_pattern? | wsl_systemd_pattern?
+        force_registration = WSLConfig.instance.product_switched? ||
+          wsl_gui_pattern? || wsl_systemd_pattern?
 
         Registration::Storage::InstallationOptions.instance.yaml_product = yaml_product
         Registration::Storage::InstallationOptions.instance.force_registration = force_registration

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -89,8 +89,8 @@ module Y2Firstboot
             ),
             VSpacing(2),
             # TRANSLATORS:
-            Label(_("The WSL GUI pattern provides some needed packages for\n" \
-              "a better experience with graphical applications in WSL.")),
+            Left(Label(_("The WSL GUI pattern provides some needed packages for\n" \
+              "a better experience with graphical applications in WSL."))),
             VSpacing(1),
             # TRANSLATORS: check box label
             Left(CheckBox(Id(:wsl_gui_pattern),
@@ -98,8 +98,8 @@ module Y2Firstboot
               wsl_gui_pattern)),
             VSpacing(2),
             # TRANSLATORS:
-            Label(_("The WSL systemd pattern provides wsl.conf adjustment\n" \
-              "and init symlink for a systemd enablement in WSL.")),
+            Left(Label(_("The WSL systemd pattern provides wsl.conf adjustment\n" \
+              "and init symlink for systemd enablement in WSL."))),
             VSpacing(1),
             # TRANSLATORS: check box label
             Left(CheckBox(Id(:wsl_systemd_pattern),
@@ -120,7 +120,8 @@ module Y2Firstboot
           # TRANSLATORS: help text (3/3)
           _("<p>For enablement of systemd in WSL the WSL systemd pattern provides wsl.conf " \
               "and /sbin/init adjustments. " \
-              "In that case the system needs to be registered as well.</p>")
+              "In that case the system needs to be registered as well. " \
+              "Also be aware that systemd enablement is in effect only after relaunch.</p>")
       end
 
     private

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -73,6 +73,8 @@ module Y2Firstboot
         _("Product Selection")
       end
 
+      # disable rubocop metrics as yast ui is constructed with methods
+      # rubocop:disable Metrics/AbcSize
       def dialog_content
         items = products.map { |p| item_for(p) }
 
@@ -108,6 +110,7 @@ module Y2Firstboot
           )
         )
       end
+      # rubocop:enable Metrics/AbcSize
 
       def help_text
         # TRANSLATORS: help text (1/3)

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -39,18 +39,24 @@ module Y2Firstboot
       # @return [Boolean]
       attr_reader :wsl_gui_pattern
 
+      # Whether the WSL systemd pattern was selected
+      #
+      # @return [Boolean]
+      attr_reader :wsl_systemd_pattern
+
       # Constructor
       #
       # @param products [Array<Hash>] All possible products
       # @param default_product [Hash] Product selected by default
       # @param wsl_gui_pattern [Boolean] Whether WSL GUI pattern is selected by default
-      def initialize(products, default_product: nil, wsl_gui_pattern: false)
+      def initialize(products, default_product: nil, wsl_gui_pattern: false, wsl_systemd_pattern: false)
         textdomain "firstboot"
 
         super()
         @products = products
         @product = default_product || products.first
         @wsl_gui_pattern = wsl_gui_pattern
+        @wsl_systemd_pattern = wsl_systemd_pattern
       end
 
       def next_handler
@@ -87,17 +93,28 @@ module Y2Firstboot
             # TRANSLATORS: check box label
             Left(CheckBox(Id(:wsl_gui_pattern),
               _("Install WSL GUI pattern (requires registration)"),
-              wsl_gui_pattern))
+              wsl_gui_pattern)),
+            # TRANSLATORS:
+            Label(_("The WSL systemd pattern provides wsl.conf adjustment and init symlink for\n" \
+              "a systemd enablement in WSL.")),
+            VSpacing(1),
+            # TRANSLATORS: check box label
+            Left(CheckBox(Id(:wsl_systemd_pattern),
+              _("Install WSL systemd pattern (requires registration)"),
+              wsl_systemd_pattern))
           )
         )
       end
 
       def help_text
-        # TRANSLATORS: help text (1/2)
+        # TRANSLATORS: help text (1/3)
         _("<p>Select the product to use with Windows Subsystem for Linux (WSL). " \
           "Some products might require registration.</p>") +
-          # TRANSLATORS: help text (2/2)
-          _("<p>To use graphical programs in WSL you need to install the WSL GUI pattern. " \
+          # TRANSLATORS: help text (2/3)
+          _("<p>For smoother experience with graphical programs in WSL the WSL GUI pattern provides recommended config, tools and libraries. " \
+              "In that case the system needs to be registered as well.</p>") +
+          # TRANSLATORS: help text (3/3)
+          _("<p>For enablement of systemd in WSL the WSL systemd pattern provides wsl.conf and /sbin/init adjustments. " \
               "In that case the system needs to be registered as well.</p>")
       end
 
@@ -146,6 +163,7 @@ module Y2Firstboot
 
       def save
         @wsl_gui_pattern = Yast::UI.QueryWidget(Id(:wsl_gui_pattern), :Value)
+        @wsl_systemd_pattern = Yast::UI.QueryWidget(Id(:wsl_systemd_pattern), :Value)
 
         selected_id = Yast::UI.QueryWidget(Id(:product_selector), :Value)
         @product = products.find { |p| item_id(p) == selected_id }

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -96,9 +96,10 @@ module Y2Firstboot
             Left(CheckBox(Id(:wsl_gui_pattern),
               _("Install WSL GUI pattern (requires registration)"),
               wsl_gui_pattern)),
+            VSpacing(2),
             # TRANSLATORS:
-            Label(_("The WSL systemd pattern provides wsl.conf adjustment and init symlink for\n" \
-              "a systemd enablement in WSL.")),
+            Label(_("The WSL systemd pattern provides wsl.conf adjustment\n" \
+              "and init symlink for a systemd enablement in WSL.")),
             VSpacing(1),
             # TRANSLATORS: check box label
             Left(CheckBox(Id(:wsl_systemd_pattern),

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -124,7 +124,7 @@ module Y2Firstboot
           _("<p>For enablement of systemd in WSL the WSL systemd pattern provides wsl.conf " \
               "and /sbin/init adjustments. " \
               "In that case the system needs to be registered as well. " \
-              "Also be aware that systemd enablement is in effect only after relaunch.</p>")
+              "Relaunch is required to use systemd.</p>")
       end
 
     private

--- a/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
+++ b/src/lib/y2firstboot/dialogs/wsl_product_selection.rb
@@ -49,7 +49,9 @@ module Y2Firstboot
       # @param products [Array<Hash>] All possible products
       # @param default_product [Hash] Product selected by default
       # @param wsl_gui_pattern [Boolean] Whether WSL GUI pattern is selected by default
-      def initialize(products, default_product: nil, wsl_gui_pattern: false, wsl_systemd_pattern: false)
+      # @param wsl_systemd_pattern [Boolean] Whether WSL systemd pattern is selected by default
+      def initialize(products, default_product: nil, wsl_gui_pattern: false,
+        wsl_systemd_pattern: false)
         textdomain "firstboot"
 
         super()
@@ -111,10 +113,12 @@ module Y2Firstboot
         _("<p>Select the product to use with Windows Subsystem for Linux (WSL). " \
           "Some products might require registration.</p>") +
           # TRANSLATORS: help text (2/3)
-          _("<p>For smoother experience with graphical programs in WSL the WSL GUI pattern provides recommended config, tools and libraries. " \
+          _("<p>For smoother experience with graphical programs in WSL " \
+              "the WSL GUI pattern provides recommended config, tools and libraries. " \
               "In that case the system needs to be registered as well.</p>") +
           # TRANSLATORS: help text (3/3)
-          _("<p>For enablement of systemd in WSL the WSL systemd pattern provides wsl.conf and /sbin/init adjustments. " \
+          _("<p>For enablement of systemd in WSL the WSL systemd pattern provides wsl.conf " \
+              "and /sbin/init adjustments. " \
               "In that case the system needs to be registered as well.</p>")
       end
 

--- a/test/y2firstboot/clients/wsl_product_selection_test.rb
+++ b/test/y2firstboot/clients/wsl_product_selection_test.rb
@@ -104,9 +104,9 @@ describe Y2Firstboot::Clients::WSLProductSelection do
 
         let(:dialog) do
           instance_double(Y2Firstboot::Dialogs::WSLProductSelection,
-            run:             dialog_result,
-            product:         selected_product,
-            wsl_gui_pattern: wsl_gui_pattern,
+            run:                 dialog_result,
+            product:             selected_product,
+            wsl_gui_pattern:     wsl_gui_pattern,
             wsl_systemd_pattern: wsl_systemd_pattern)
         end
 

--- a/test/y2firstboot/dialogs/wsl_product_selection_test.rb
+++ b/test/y2firstboot/dialogs/wsl_product_selection_test.rb
@@ -43,10 +43,9 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
 
   subject do
     described_class.new(products,
-      default_product: default_product,
-      wsl_gui_pattern: wsl_gui_pattern,
-      wsl_systemd_pattern: wsl_systemd_pattern
-      )
+      default_product:     default_product,
+      wsl_gui_pattern:     wsl_gui_pattern,
+      wsl_systemd_pattern: wsl_systemd_pattern)
   end
 
   let(:products) { [sles, sled] }
@@ -141,7 +140,8 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
     before do
       allow(Yast::UI).to receive(:QueryWidget).and_call_original
       allow(Yast::UI).to receive(:QueryWidget).with(Id(:wsl_gui_pattern), :Value).and_return(true)
-      allow(Yast::UI).to receive(:QueryWidget).with(Id(:wsl_systemd_pattern), :Value).and_return(true)
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:wsl_systemd_pattern), :Value)
+        .and_return(true)
       allow(Yast::UI).to receive(:QueryWidget).with(Id(:product_selector), :Value)
         .and_return("SLES:15.4")
     end

--- a/test/y2firstboot/dialogs/wsl_product_selection_test.rb
+++ b/test/y2firstboot/dialogs/wsl_product_selection_test.rb
@@ -43,7 +43,10 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
 
   subject do
     described_class.new(products,
-      default_product: default_product, wsl_gui_pattern: wsl_gui_pattern)
+      default_product: default_product,
+      wsl_gui_pattern: wsl_gui_pattern,
+      wsl_systemd_pattern: wsl_systemd_pattern
+      )
   end
 
   let(:products) { [sles, sled] }
@@ -52,6 +55,7 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
 
   let(:default_product) { sled }
   let(:wsl_gui_pattern) { false }
+  let(:wsl_systemd_pattern) { false }
 
   let(:installed_product) { double(Y2Packager::Resolvable, name: "SLES", version_version: "15.4") }
   before do
@@ -76,6 +80,12 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
 
     it "shows a check box for selecting the WSL GUI pattern" do
       widget = find_widget(:wsl_gui_pattern, subject.send(:dialog_content))
+
+      expect(widget).to_not be_nil
+    end
+
+    it "shows a check box for selecting the WSL systemd pattern" do
+      widget = find_widget(:wsl_systemd_pattern, subject.send(:dialog_content))
 
       expect(widget).to_not be_nil
     end
@@ -105,12 +115,33 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
         expect(widget.params.last).to eq(false)
       end
     end
+
+    context "when WSL systemd pattern is indicated as selected" do
+      let(:wsl_systemd_pattern) { true }
+
+      it "selects WSL systemd pattern checkbox by default" do
+        widget = find_widget(:wsl_systemd_pattern, subject.send(:dialog_content))
+
+        expect(widget.params.last).to eq(true)
+      end
+    end
+
+    context "when WSL systemd pattern is not indicated as selected" do
+      let(:wsl_systemd_pattern) { false }
+
+      it "does not select WSL systemd pattern checkbox by default" do
+        widget = find_widget(:wsl_systemd_pattern, subject.send(:dialog_content))
+
+        expect(widget.params.last).to eq(false)
+      end
+    end
   end
 
   describe "#next_handler" do
     before do
       allow(Yast::UI).to receive(:QueryWidget).and_call_original
       allow(Yast::UI).to receive(:QueryWidget).with(Id(:wsl_gui_pattern), :Value).and_return(true)
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:wsl_systemd_pattern), :Value).and_return(true)
       allow(Yast::UI).to receive(:QueryWidget).with(Id(:product_selector), :Value)
         .and_return("SLES:15.4")
     end
@@ -121,6 +152,14 @@ describe Y2Firstboot::Dialogs::WSLProductSelection do
       subject.next_handler
 
       expect(subject.wsl_gui_pattern).to eq(true)
+    end
+
+    it "saves whether the WSL GUI pattern checkbox was selected" do
+      expect(subject.wsl_systemd_pattern).to eq(false)
+
+      subject.next_handler
+
+      expect(subject.wsl_systemd_pattern).to eq(true)
     end
 
     it "saves the selected product" do


### PR DESCRIPTION
## Problem

WSL now supports systemd when some tuning is done. And that tuning is packaged as pattern with bunch of deps.

jira: https://jira.suse.com/browse/PED-5099

## Solution

Implement checkbox as requested and also adapt a bit help text as mentioned in that jira entry.


## Testing

- *Added a new unit test*
- Manually tested and documented how to test it.

## Screenshot

![wsl_firstboot](https://github.com/yast/yast-firstboot/assets/478871/ba60fcc4-81a6-4655-8a2a-34eda9bf5916)

![wsl_firstboot_help](https://github.com/yast/yast-firstboot/assets/478871/69d3883a-3fab-4f6f-bad1-99d4a869d6a6)
